### PR TITLE
only display confirmed targets in target list

### DIFF
--- a/custom_code/templatetags/target_list_extras.py
+++ b/custom_code/templatetags/target_list_extras.py
@@ -1,6 +1,7 @@
 from django import template
 from ..models import Candidate, TargetListExtra
 from tom_targets.models import TargetExtra
+from guardian.shortcuts import get_objects_for_user
 import json
 
 register = template.Library()
@@ -37,3 +38,14 @@ def candidates_table(target):
     """
     candidates = Candidate.objects.filter(target=target).all()
     return {'candidates': candidates}
+
+
+@register.inclusion_tag('tom_targets/partials/recent_targets.html', takes_context=True)
+def recent_confirmed_targets(context, limit=10):
+    """
+    Displays a list of the most recently created targets in the TOM up to the given limit, or 10 if not specified.
+    """
+    user = context['request'].user
+    targets_for_user = get_objects_for_user(user, 'tom_targets.view_target')
+    confirmed_targets_for_user = targets_for_user.exclude(name__startswith='J')
+    return {'targets': confirmed_targets_for_user.order_by('-created')[:limit]}

--- a/custom_code/urls.py
+++ b/custom_code/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 
 from tom_targets.views import TargetGroupingView, TargetGroupingDeleteView
 from .views import TargetGroupingCreateView, CandidateListView, TargetReportView, TargetClassifyView, TargetVettingView
-from .views import ObservationCreateView, TargetNameSearchView
+from .views import ObservationCreateView, TargetNameSearchView, TargetListView
 
 from tom_common.api_router import SharedAPIRootRouter
 
@@ -19,5 +19,6 @@ urlpatterns = [
     path('targets/<int:pk>/classify/', TargetClassifyView.as_view(), name='classify'),
     path('targets/<int:pk>/vet/', TargetVettingView.as_view(), name='vet'),
     path('targets/search/', TargetNameSearchView.as_view(), name='search'),
+    path('targets/', TargetListView.as_view(), name='list'),
     path('observations/<str:facility>/create/', ObservationCreateView.as_view(), name='create'),
 ]

--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -11,7 +11,7 @@ from django.shortcuts import redirect
 from guardian.mixins import PermissionListMixin
 
 from tom_targets.models import Target, TargetList, TargetExtra
-from tom_targets.views import TargetNameSearchView as OldTargetNameSearchView
+from tom_targets.views import TargetNameSearchView as OldTargetNameSearchView, TargetListView as OldTargetListView
 from tom_observations.views import ObservationCreateView as OldObservationCreateView
 from custom_code.models import Candidate
 from custom_code.filters import CandidateFilter
@@ -329,3 +329,13 @@ class TargetNameSearchView(OldTargetNameSearchView):
     def get(self, request, *args, **kwargs):
         self.kwargs['name'] = request.GET.get('name').strip()
         return super().get(request, *args, **kwargs)
+
+
+class TargetListView(OldTargetListView):
+    """
+    View for listing targets in the TOM. Only shows targets that the user is authorized to view. Requires authorization.
+
+    Identical to the built-in TargetListView but does not display unconfirmed candidates (names starting with "J")
+    """
+    def get_queryset(self):
+        return super().get_queryset().exclude(name__startswith='J')

--- a/templates/tom_common/index.html
+++ b/templates/tom_common/index.html
@@ -1,5 +1,5 @@
 {% extends 'tom_common/base.html' %}
-{% load static targets_extras observation_extras dataproduct_extras tom_common_extras %}
+{% load static targets_extras target_list_extras observation_extras dataproduct_extras tom_common_extras %}
 {% block title %}Home{% endblock %}
 {% block content %}
 <div class="row">
@@ -22,7 +22,7 @@
       <div class="card-header">
         Latest Targets
       </div>
-      {% recent_targets %}
+      {% recent_confirmed_targets %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
This filters unconfirmed candidates out of the target list and the recent targets box on the home page. For now, we just identify these by name (if the name starts with "J"). This might not be the best way, but we can easily implement something more sophisticated later if it becomes a problem.