### PR TITLE
Add absolute magnitude to recent photometry table

### DIFF
--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -30,6 +30,10 @@ def target_post_save(target, created):
 
         matches, hostdict = galaxy_search(target.ra, target.dec, db_connect=DB_CONNECT)
         TargetExtra(target=target, key='Host Galaxies', value=json.dumps(hostdict)).save()
+        if hostdict:
+            target.distance = hostdict[0].get('Dist')
+            target.distance_err = hostdict[0].get('DistErr')
+            target.save()
 
         ztfphot = query_ZTFpubphot(target.ra, target.dec, db_connect=DB_CONNECT)
         if ztfphot:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django_extensions
 guardian
 flask_sqlalchemy
 fastavro
-tomtoolkit
+tomtoolkit @ git+https://github.com/griffin-h/tom_base  # use my fork until PRs are merged
 psycopg2-binary
 whitenoise
 kne_cand_vetting @ git+https://github.com/SAGUARO-MMA/kne-cand-vetting

--- a/templates/tom_dataproducts/partials/recent_photometry.html
+++ b/templates/tom_dataproducts/partials/recent_photometry.html
@@ -4,7 +4,7 @@
       Recent Photometry
     </div>
     <table class="table">
-        <thead><tr><th>Timestamp</th><th>Magnitude</th></tr></thead>
+        <thead><tr><th>Time</th><th>Mag.</th><th>Abs. Mag.</th></tr></thead>
         <tbody>
         {% for datum in data %}
         <tr>
@@ -13,6 +13,11 @@
             <td>{{ datum.magnitude|floatformat:2 }}</td>
             {% elif datum.limit %}
             <td>&gt;{{ datum.limit|floatformat:2 }}</td>
+            {% endif %}
+            {% if datum.absmag %}
+            <td>{{ datum.absmag|floatformat:2 }}</td>
+            {% else %}
+            <td></td>
             {% endif %}
         </tr>
         {% empty %}


### PR DESCRIPTION
This adds absolute magnitude to the recent photometry table, at the request of @ms1228. If there are any host galaxy crossmatches, it automatically populates the distance from the lowest-Pcc host. Otherwise, you can edit this manually.