### PR TITLE
Keep track of sources in uploaded photometry

### DIFF
--- a/custom_code/data_processor.py
+++ b/custom_code/data_processor.py
@@ -1,0 +1,41 @@
+from django.conf import settings
+from importlib import import_module
+
+from tom_dataproducts.models import ReducedDatum
+
+
+DEFAULT_DATA_PROCESSOR_CLASS = 'tom_dataproducts.data_processor.DataProcessor'
+
+
+def run_data_processor(dp):
+    """
+    Reads the `data_product_type` from the dp parameter and imports the corresponding `DataProcessor` specified in
+    `settings.py`, then runs `process_data` and inserts the returned values into the database.
+
+    :param dp: DataProduct which will be processed into a list
+    :type dp: DataProduct
+
+    :returns: QuerySet of `ReducedDatum` objects created by the `run_data_processor` call
+    :rtype: `QuerySet` of `ReducedDatum`
+    """
+
+    try:
+        processor_class = settings.DATA_PROCESSORS[dp.data_product_type]
+    except Exception:
+        processor_class = DEFAULT_DATA_PROCESSOR_CLASS
+
+    try:
+        mod_name, class_name = processor_class.rsplit('.', 1)
+        mod = import_module(mod_name)
+        clazz = getattr(mod, class_name)
+    except (ImportError, AttributeError):
+        raise ImportError('Could not import {}. Did you provide the correct path?'.format(processor_class))
+
+    data_processor = clazz()
+    data = data_processor.process_data(dp)
+
+    reduced_datums = [ReducedDatum(target=dp.target, data_product=dp, data_type=dp.data_product_type,
+                                   timestamp=datum[0], value=datum[1], source_name=datum[2]) for datum in data]
+    ReducedDatum.objects.bulk_create(reduced_datums)
+
+    return ReducedDatum.objects.filter(data_product=dp)

--- a/custom_code/processors/photometry_processor.py
+++ b/custom_code/processors/photometry_processor.py
@@ -1,0 +1,65 @@
+import mimetypes
+
+from astropy import units
+from astropy.io import ascii
+from astropy.time import Time, TimezoneInfo
+
+from tom_dataproducts.processors.photometry_processor import PhotometryProcessor as OldPhotometryProcessor
+from tom_dataproducts.exceptions import InvalidFileFormatException
+
+
+class PhotometryProcessor(OldPhotometryProcessor):
+
+    def process_data(self, data_product):
+        """
+        Routes a photometry processing call to a method specific to a file-format.
+
+        :param data_product: Photometric DataProduct which will be processed into the specified format for database
+        ingestion
+        :type data_product: DataProduct
+
+        :returns: python list of 2-tuples, each with a timestamp and corresponding data
+        :rtype: list
+        """
+
+        mimetype = mimetypes.guess_type(data_product.data.path)[0]
+        if mimetype in self.PLAINTEXT_MIMETYPES:
+            photometry = self._process_photometry_from_plaintext(data_product)
+            return [(datum.pop('timestamp'), datum, datum.pop('source', None)) for datum in photometry]
+        else:
+            raise InvalidFileFormatException('Unsupported file type')
+
+    def _process_photometry_from_plaintext(self, data_product):
+        """
+        Processes the photometric data from a plaintext file into a list of dicts. File is read using astropy as
+        specified in the below documentation. The file is expected to be a multi-column delimited file, with headers for
+        time, magnitude, filter, and error.
+        # http://docs.astropy.org/en/stable/io/ascii/read.html
+
+        :param data_product: Photometric DataProduct which will be processed into a list of dicts
+        :type data_product: DataProduct
+
+        :returns: python list containing the photometric data from the DataProduct
+        :rtype: list
+        """
+
+        photometry = []
+
+        data = ascii.read(data_product.data.path)
+        if len(data) < 1:
+            raise InvalidFileFormatException('Empty table or invalid file type')
+
+        for datum in data:
+            time = Time(float(datum['time']), format='mjd')
+            utc = TimezoneInfo(utc_offset=0*units.hour)
+            time.format = 'datetime'
+            value = {
+                'timestamp': time.to_datetime(timezone=utc),
+                'magnitude': datum['magnitude'],
+                'filter': datum['filter'],
+                'error': datum['error'],
+                'source': datum['source'] if 'source' in data.colnames else None
+            }
+            photometry.append(value)
+
+        return photometry

--- a/custom_code/processors/photometry_processor.py
+++ b/custom_code/processors/photometry_processor.py
@@ -25,7 +25,7 @@ class PhotometryProcessor(OldPhotometryProcessor):
         mimetype = mimetypes.guess_type(data_product.data.path)[0]
         if mimetype in self.PLAINTEXT_MIMETYPES:
             photometry = self._process_photometry_from_plaintext(data_product)
-            return [(datum.pop('timestamp'), datum, datum.pop('source', None)) for datum in photometry]
+            return [(datum.pop('timestamp'), datum, datum.pop('source', '')) for datum in photometry]
         else:
             raise InvalidFileFormatException('Unsupported file type')
 
@@ -58,7 +58,7 @@ class PhotometryProcessor(OldPhotometryProcessor):
                 'magnitude': datum['magnitude'],
                 'filter': datum['filter'],
                 'error': datum['error'],
-                'source': datum['source'] if 'source' in data.colnames else None
+                'source': datum['source'] if 'source' in data.colnames else ''
             }
             photometry.append(value)
 

--- a/custom_code/processors/spectroscopy_processor.py
+++ b/custom_code/processors/spectroscopy_processor.py
@@ -1,10 +1,36 @@
+import mimetypes
 from specutils import Spectrum1D
+from tom_dataproducts.processors.data_serializers import SpectrumSerializer
 from tom_dataproducts.processors.spectroscopy_processor import SpectroscopyProcessor as OldSpectroscopyProcessor
 from tom_dataproducts.exceptions import InvalidFileFormatException
 from lightcurve_fitting.speccal import readspec
 
 
 class SpectroscopyProcessor(OldSpectroscopyProcessor):
+
+    def process_data(self, data_product):
+        """
+        Routes a spectroscopy processing call to a method specific to a file-format, then serializes the returned data.
+
+        :param data_product: Spectroscopic DataProduct which will be processed into the specified format for database
+        ingestion
+        :type data_product: DataProduct
+
+        :returns: python list of 2-tuples, each with a timestamp and corresponding data
+        :rtype: list
+        """
+
+        mimetype = mimetypes.guess_type(data_product.data.path)[0]
+        if mimetype in self.FITS_MIMETYPES:
+            spectrum, obs_date = self._process_spectrum_from_fits(data_product)
+        elif mimetype in self.PLAINTEXT_MIMETYPES:
+            spectrum, obs_date = self._process_spectrum_from_plaintext(data_product)
+        else:
+            raise InvalidFileFormatException('Unsupported file type')
+
+        serialized_spectrum = SpectrumSerializer().serialize(spectrum)
+
+        return [(obs_date, serialized_spectrum, None)]  # no support for source_name yet
 
     def _process_spectrum_from_plaintext(self, data_product):
         """

--- a/custom_code/processors/spectroscopy_processor.py
+++ b/custom_code/processors/spectroscopy_processor.py
@@ -30,7 +30,7 @@ class SpectroscopyProcessor(OldSpectroscopyProcessor):
 
         serialized_spectrum = SpectrumSerializer().serialize(spectrum)
 
-        return [(obs_date, serialized_spectrum, None)]  # no support for source_name yet
+        return [(obs_date, serialized_spectrum, '')]  # no support for source_name yet
 
     def _process_spectrum_from_plaintext(self, data_product):
         """

--- a/custom_code/templatetags/photometry_extras.py
+++ b/custom_code/templatetags/photometry_extras.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from guardian.shortcuts import get_objects_for_user
 from plotly import offline
 import plotly.graph_objs as go
+from plotly.express import colors
 from tom_dataproducts.models import ReducedDatum
 import numpy as np
 
@@ -25,6 +26,9 @@ MARKER_MAP = {
     'SAGUARO pipeline': 0,  # circle
     'ZTF': 1,  # square
 }
+OTHER_MARKERS = list(range(33))  # all filled markers in Plotly
+OTHER_MARKERS.remove(6)  # do not use triangle-down, too close to arrow-bar-down
+OTHER_COLORS = colors.qualitative.Plotly  # default Plotly color sequence
 
 
 @register.inclusion_tag('tom_dataproducts/partials/recent_photometry.html', takes_context=True)
@@ -109,11 +113,22 @@ def photometry_for_target(context, target, width=700, height=600, background=Non
     plot_data = []
     for source_name, source_values in detections.items():
         for filter_name, filter_values in source_values.items():
+            # get unique color and marker for this data series
+            if filter_name not in COLOR_MAP:
+                for new_color in OTHER_COLORS:
+                    if new_color not in COLOR_MAP.values():
+                        COLOR_MAP[filter_name] = new_color
+                        break
+            if source_name not in MARKER_MAP:
+                for new_marker in OTHER_MARKERS:
+                    if new_marker not in MARKER_MAP.values():
+                        MARKER_MAP[source_name] = new_marker
+                        break
             series = go.Scatter(
                 x=filter_values['time'],
                 y=filter_values['magnitude'],
                 mode='markers',
-                marker=dict(color=COLOR_MAP.get(filter_name)),
+                marker_color=COLOR_MAP.get(filter_name),
                 marker_symbol=MARKER_MAP.get(source_name),
                 name=f'{source_name} {filter_name}',
                 error_y=dict(
@@ -125,12 +140,18 @@ def photometry_for_target(context, target, width=700, height=600, background=Non
             plot_data.append(series)
     for source_name, source_values in limits.items():
         for filter_name, filter_values in source_values.items():
+            # get unique color for this data series
+            if filter_name not in COLOR_MAP:
+                for new_color in OTHER_COLORS:
+                    if new_color not in COLOR_MAP.values():
+                        COLOR_MAP[filter_name] = new_color
+                        break
             series = go.Scatter(
                 x=filter_values['time'],
                 y=filter_values['limit'],
                 mode='markers',
                 opacity=0.5,
-                marker=dict(color=COLOR_MAP.get(filter_name)),
+                marker_color=COLOR_MAP.get(filter_name),
                 marker_symbol=MARKER_MAP['limit'],
                 name=f'{source_name} {filter_name} limits',
             )

--- a/custom_code/urls.py
+++ b/custom_code/urls.py
@@ -2,7 +2,8 @@ from django.urls import path
 
 from tom_targets.views import TargetGroupingView, TargetGroupingDeleteView
 from .views import TargetGroupingCreateView, CandidateListView, TargetReportView, TargetClassifyView, TargetVettingView
-from .views import ObservationCreateView, TargetNameSearchView, TargetListView, TargetATLASForcedPhot, TargetTNSPhotometry
+from .views import ObservationCreateView, TargetNameSearchView, TargetListView, TargetATLASForcedPhot
+from .views import TargetTNSPhotometry, DataProductUploadView
 
 from tom_common.api_router import SharedAPIRootRouter
 
@@ -23,4 +24,5 @@ urlpatterns = [
     path('targets/search/', TargetNameSearchView.as_view(), name='search'),
     path('targets/', TargetListView.as_view(), name='list'),
     path('observations/<str:facility>/create/', ObservationCreateView.as_view(), name='create'),
+    path('dataproducts/data/upload/', DataProductUploadView.as_view(), name='upload'),
 ]

--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
@@ -9,14 +10,18 @@ from django.views.generic.edit import CreateView, TemplateResponseMixin, FormMix
 from django_filters.views import FilterView
 from django.shortcuts import redirect
 from guardian.mixins import PermissionListMixin
-from guardian.shortcuts import get_objects_for_user
+from guardian.shortcuts import get_objects_for_user, assign_perm
 
+from tom_common.hooks import run_hook
 from tom_targets.models import Target, TargetList, TargetExtra
 from tom_targets.views import TargetNameSearchView as OldTargetNameSearchView, TargetListView as OldTargetListView
 from tom_observations.views import ObservationCreateView as OldObservationCreateView
-from tom_dataproducts.models import ReducedDatum
+from tom_dataproducts.exceptions import InvalidFileFormatException
+from tom_dataproducts.models import DataProduct, ReducedDatum
+from tom_dataproducts.views import DataProductUploadView as OldDataProductUploadView
 from custom_code.models import Candidate
 from custom_code.filters import CandidateFilter
+from .data_processor import run_data_processor
 from .forms import TargetListExtraFormset, TargetReportForm, TargetClassifyForm
 from .forms import TNS_FILTER_CHOICES, TNS_INSTRUMENT_CHOICES, TNS_CLASSIFICATION_CHOICES
 
@@ -452,3 +457,57 @@ class TargetListView(OldTargetListView):
     """
     def get_queryset(self):
         return super().get_queryset().exclude(name__startswith='J')
+
+
+class DataProductUploadView(OldDataProductUploadView):
+
+    def form_valid(self, form):
+        """
+        Runs after ``DataProductUploadForm`` is validated. Saves each ``DataProduct`` and calls ``run_data_processor``
+        on each saved file. Redirects to the previous page.
+        """
+        target = form.cleaned_data['target']
+        if not target:
+            observation_record = form.cleaned_data['observation_record']
+            target = observation_record.target
+        else:
+            observation_record = None
+        dp_type = form.cleaned_data['data_product_type']
+        data_product_files = self.request.FILES.getlist('files')
+        successful_uploads = []
+        for f in data_product_files:
+            dp = DataProduct(
+                target=target,
+                observation_record=observation_record,
+                data=f,
+                product_id=None,
+                data_product_type=dp_type
+            )
+            dp.save()
+            try:
+                run_hook('data_product_post_upload', dp)
+                reduced_data = run_data_processor(dp)
+                if not settings.TARGET_PERMISSIONS_ONLY:
+                    for group in form.cleaned_data['groups']:
+                        assign_perm('tom_dataproducts.view_dataproduct', group, dp)
+                        assign_perm('tom_dataproducts.delete_dataproduct', group, dp)
+                        assign_perm('tom_dataproducts.view_reduceddatum', group, reduced_data)
+                successful_uploads.append(str(dp))
+            except InvalidFileFormatException as iffe:
+                ReducedDatum.objects.filter(data_product=dp).delete()
+                dp.delete()
+                messages.error(
+                    self.request,
+                    'File format invalid for file {0} -- error was {1}'.format(str(dp), iffe)
+                )
+            except Exception:
+                ReducedDatum.objects.filter(data_product=dp).delete()
+                dp.delete()
+                messages.error(self.request, 'There was a problem processing your file: {0}'.format(str(dp)))
+        if successful_uploads:
+            messages.success(
+                self.request,
+                'Successfully uploaded: {0}'.format('\n'.join([p for p in successful_uploads]))
+            )
+
+        return redirect(form.cleaned_data.get('referrer', '/'))

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -236,7 +236,7 @@ DATA_PRODUCT_TYPES = {
 }
 
 DATA_PROCESSORS = {
-    'photometry': 'tom_dataproducts.processors.photometry_processor.PhotometryProcessor',
+    'photometry': 'custom_code.processors.photometry_processor.PhotometryProcessor',
     'spectroscopy': 'custom_code.processors.spectroscopy_processor.SpectroscopyProcessor',
 }
 


### PR DESCRIPTION
This resolves #30 by storing sources in the "source" column of uploaded photometry table in the `ReducedDatum.source_name` attribute. These are already separated into different data series with distinct markers in the photometry plot.