### PR TITLE
Add TNS query to vetting button

### DIFF
--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -345,7 +345,7 @@ class TargetVettingView(LoginRequiredMixin, RedirectView):
             update_or_create_target_extra(target=target, key='ASASSN Prob.', value=asassnprob[0])
             update_or_create_target_extra(target=target, key='ASASSN Offset', value=asassnoffset[0])
 
-        matches, hostdict = galaxy_search([target.ra], [target.dec], db_connect=DB_CONNECT)
+        matches, hostdict = galaxy_search(target.ra, target.dec, db_connect=DB_CONNECT)
         update_or_create_target_extra(target=target, key='Host Galaxies', value=json.dumps(hostdict))
 
         return HttpResponseRedirect(self.get_redirect_url())

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ fastavro
 tomtoolkit @ git+https://github.com/griffin-h/tom_base  # use my fork until PRs are merged
 psycopg2-binary
 whitenoise
-kne_cand_vetting @ git+https://github.com/SAGUARO-MMA/kne-cand-vetting@tns_query
+kne_cand_vetting @ git+https://github.com/SAGUARO-MMA/kne-cand-vetting
 lightcurve-fitting
 mmtapi @ git+https://github.com/swyatt7/mmtapi  # the latest version is not on PyPI

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ fastavro
 tomtoolkit @ git+https://github.com/griffin-h/tom_base  # use my fork until PRs are merged
 psycopg2-binary
 whitenoise
-kne_cand_vetting @ git+https://github.com/SAGUARO-MMA/kne-cand-vetting
+kne_cand_vetting @ git+https://github.com/SAGUARO-MMA/kne-cand-vetting#tns_query
 lightcurve-fitting
 mmtapi @ git+https://github.com/swyatt7/mmtapi  # the latest version is not on PyPI

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ fastavro
 tomtoolkit @ git+https://github.com/griffin-h/tom_base  # use my fork until PRs are merged
 psycopg2-binary
 whitenoise
-kne_cand_vetting @ git+https://github.com/SAGUARO-MMA/kne-cand-vetting#tns_query
+kne_cand_vetting @ git+https://github.com/SAGUARO-MMA/kne-cand-vetting@tns_query
 lightcurve-fitting
 mmtapi @ git+https://github.com/swyatt7/mmtapi  # the latest version is not on PyPI


### PR DESCRIPTION
This resolves #39 by crossmatching against our local copy of the TNS when the "Vet" button is clicked. If a match is found, the name, classification, and redshift are updated accordingly. Once the name is updated, the "Get TNS phot." button will appear.

I updated `requirements.txt` to point to a branch of the `kne_cand_vetting` package until [SAGUARO-MMA/kne_cand_vetting#10](https://github.com/SAGUARO-MMA/kne-cand-vetting/pull/10) is merged.

For some reason, we were still calling `galaxy_search` with a list of coordinates, which was causing the request to hang. I fixed this too (already matches what was in the `target_post_save hook`).