### PR TITLE
Extract and ingest 1D spectra from MMT tar file

### DIFF
--- a/custom_code/processors/spectroscopy_processor.py
+++ b/custom_code/processors/spectroscopy_processor.py
@@ -13,6 +13,11 @@ class SpectroscopyProcessor(OldSpectroscopyProcessor):
         """
         Routes a spectroscopy processing call to a method specific to a file-format, then serializes the returned data.
 
+        Parsing of the spectrum file is handled by the lightcurve-fitting
+        package: https://griffin-h.github.io/lightcurve_fitting/api.html#lightcurve_fitting.speccal.readspec.
+
+        Serialization removes any NaN values, which cannot be stored in a JSONField.
+
         :param data_product: Spectroscopic DataProduct which will be processed into the specified format for database
         ingestion
         :type data_product: DataProduct
@@ -20,44 +25,14 @@ class SpectroscopyProcessor(OldSpectroscopyProcessor):
         :returns: python list of 2-tuples, each with a timestamp and corresponding data
         :rtype: list
         """
-
-        mimetype = mimetypes.guess_type(data_product.data.path)[0]
-        if mimetype in self.FITS_MIMETYPES:
-            spectrum, obs_date = self._process_spectrum_from_fits(data_product)
-        elif mimetype in self.PLAINTEXT_MIMETYPES:
-            spectrum, obs_date = self._process_spectrum_from_plaintext(data_product)
-        else:
-            raise InvalidFileFormatException('Unsupported file type')
-
-        serialized_spectrum = FiniteSpectrumSerializer().serialize(spectrum)
-
-        return [(obs_date, serialized_spectrum, '')]  # no support for source_name yet
-
-    def _process_spectrum_from_plaintext(self, data_product):
-        """
-        Processes the data from a spectrum from a plaintext file into a Spectrum1D object, which can then be serialized
-        and stored as a ReducedDatum for further processing or display. Text files are read using the lightcurve-fitting
-        package: https://griffin-h.github.io/lightcurve_fitting/api.html#lightcurve_fitting.speccal.readspec.
-
-        Parameters
-        ----------
-        :param data_product: Spectroscopic DataProduct which will be processed into a Spectrum1D
-        :type data_product: tom_dataproducts.models.DataProduct
-
-        :returns: Spectrum1D object containing the data from the DataProduct
-        :rtype: specutils.Spectrum1D
-
-        :returns: Datetime of observation, if it is in the comments and the file is from a supported facility, current
-            datetime otherwise
-        :rtype: datetime.datetime
-        """
-
-        wavelength, flux, date_obs, telescope, instrument = readspec(data_product.data.path)
+        wavelength, flux, obs_date, telescope, instrument = readspec(data_product.data.path)
         if len(flux) < 1:
             raise InvalidFileFormatException('Empty table or invalid file type')
         spectrum = Spectrum1D(flux=flux * self.DEFAULT_FLUX_CONSTANT,
                               spectral_axis=wavelength * self.DEFAULT_WAVELENGTH_UNITS)
-        return spectrum, date_obs.to_datetime()
+        serialized_spectrum = FiniteSpectrumSerializer().serialize(spectrum)
+
+        return [(obs_date.to_datetime(), serialized_spectrum, '')]  # no support for source_name yet
 
 
 class FiniteSpectrumSerializer(SpectrumSerializer):

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ ligo.skymap
 numpy
 tomtoolkit~=2.15.14
 tom-alertstreams
-tom-mmt @ git+https://github.com/griffin-h/tom_mmt
+tom-mmt~=0.1.3
 tom-nonlocalizedevents~=0.7.7
 twilio
 paramiko

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -249,7 +249,7 @@ DATA_PRODUCT_TYPES = {
 DATA_PROCESSORS = {
     'photometry': 'tom_dataproducts.processors.photometry_processor.PhotometryProcessor',
     'spectroscopy': 'custom_code.processors.spectroscopy_processor.SpectroscopyProcessor',
-    '1D FITS Tar': 'tom_mmt.mmt.MMTDataProcessor',
+    'MMT': 'tom_mmt.mmt.MMTDataProcessor',
 }
 
 TOM_FACILITY_CLASSES = [

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -249,6 +249,7 @@ DATA_PRODUCT_TYPES = {
 DATA_PROCESSORS = {
     'photometry': 'tom_dataproducts.processors.photometry_processor.PhotometryProcessor',
     'spectroscopy': 'custom_code.processors.spectroscopy_processor.SpectroscopyProcessor',
+    '1D FITS Tar': 'tom_mmt.mmt.MMTDataProcessor',
 }
 
 TOM_FACILITY_CLASSES = [

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -243,7 +243,8 @@ DATA_PRODUCT_TYPES = {
     'photometry': ('photometry', 'Photometry'),
     'fits_file': ('fits_file', 'FITS File'),
     'spectroscopy': ('spectroscopy', 'Spectroscopy'),
-    'image_file': ('image_file', 'Image File')
+    'image_file': ('image_file', 'Image File'),
+    'MMT': ('MMT', 'MMT File'),
 }
 
 DATA_PROCESSORS = {


### PR DESCRIPTION
This updates the TOM settings to use the new `tom-mmt` data processor, which extracts spectra from the MMT tar files and ingests them as `ReducedDatum`s. It also updates the `SpectrumSerializer` to remove all NaN values from the spectrum before saving, because these are not allowed in `JSONField`s.