### PR TITLE
Add ingest_tns management command

### DIFF
--- a/custom_code/forms.py
+++ b/custom_code/forms.py
@@ -408,11 +408,12 @@ class CandidateFormHelper(FormHelper):
             Column('mlscore_bogus_range'),
         ),
         Row(
+            Column('target__name__startswith'),
             Column('cone_search'),
             Column('observation_record__survey_field'),
             Column('classification'),
             Column('localization'),
-            Column('order', css_class='col-md-4'),
+            Column('order'),
         ),
         Row(
             Column(

--- a/custom_code/management/commands/ingest_tns.py
+++ b/custom_code/management/commands/ingest_tns.py
@@ -1,0 +1,149 @@
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from django.db import connection
+from tom_targets.models import Target
+from ...hooks import target_post_save
+import requests
+import json
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+
+    help = 'Updates, merges, and adds targets from the tns_q3c table (maintained outside the TOM Toolkit)'
+
+    def handle(self, **kwargs):
+        logger.info('Crossmatching TNS with targets table. This will take several minutes.')
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                --STEP 1: crossmatch TNS transients with existing targets and store in tns_matches table
+                SELECT target.id, target.name, t.tns_name, t.sep, t.ra, t.dec INTO tns_matches
+                FROM tom_targets_target AS target LEFT JOIN LATERAL (
+                    SELECT CONCAT(tns.name_prefix, tns.name) AS tns_name,
+                        q3c_dist(target.ra, target.dec, tns.ra, tns.declination) AS sep,
+                        tns.ra,
+                        tns.declination as dec
+                    FROM tns_q3c AS tns
+                    WHERE q3c_join(target.ra, target.dec, tns.ra, tns.declination, 2. / 3600) AND name_prefix != 'FRB'
+                    ORDER BY sep, discoverydate LIMIT 1 -- if there are duplicates in the TNS, use the earlier one
+                ) AS t ON true
+                WHERE t.tns_name IS NOT NULL;
+                
+                SELECT DISTINCT ON (tns_name) * INTO top_tns_matches
+                FROM tns_matches
+                ORDER BY tns_name, sep, name; -- if there are duplicates in the TNS, use the earlier one
+                
+                DELETE FROM tns_matches
+                WHERE name IN (
+                    SELECT name from top_tns_matches
+                );
+                """
+            )
+
+        updated_targets = Target.objects.raw(
+            """
+            --STEP 2: update existing targets (if needed) to match closest TNS transient
+            UPDATE tom_targets_target AS tt
+            SET name=tm.tns_name, ra=tm.ra, dec=tm.dec, modified=NOW()
+            FROM top_tns_matches AS tm
+            WHERE tt.name=tm.name AND (tm.name != tm.tns_name OR sep > 0)
+            RETURNING tt.*;
+            """
+        )
+        logger.info(f"Updated {len(updated_targets):d} targets to match the TNS.")
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                --STEP 3: merge any other matches into the new target
+                SELECT tm.id AS old_id, ttm.id  AS new_id, tm.name AS old_name, ttm.name AS new_name
+                INTO targets_to_merge
+                FROM tns_matches as tm
+                JOIN top_tns_matches AS ttm ON ttm.name=tm.tns_name;
+                
+                UPDATE candidates
+                SET targetid=new_id
+                FROM targets_to_merge
+                WHERE targetid=old_id;
+                
+                UPDATE tom_dataproducts_dataproduct
+                SET target_id=new_id
+                FROM targets_to_merge
+                WHERE target_id=old_id;
+                
+                UPDATE tom_dataproducts_reduceddatum
+                SET target_id=new_id
+                FROM targets_to_merge
+                WHERE target_id=old_id;
+                
+                UPDATE tom_nonlocalizedevents_eventcandidate
+                SET target_id=new_id
+                FROM targets_to_merge
+                WHERE target_id=old_id;
+                
+                UPDATE tom_observations_observationrecord
+                SET target_id=new_id
+                FROM targets_to_merge
+                WHERE target_id=old_id;
+                
+                UPDATE tom_targets_targetextra
+                SET target_id=new_id
+                FROM targets_to_merge
+                WHERE target_id=old_id;
+                
+                UPDATE tom_targets_targetlist_targets
+                SET target_id=new_id
+                FROM targets_to_merge
+                WHERE target_id=old_id;
+                
+                UPDATE tom_targets_targetname
+                SET target_id=new_id
+                FROM targets_to_merge
+                WHERE target_id=old_id;
+                """
+            )
+
+        deleted_targets = Target.objects.raw(
+            """
+            DELETE FROM tom_targets_target
+            WHERE id IN (
+                SELECT old_id FROM targets_to_merge
+            )
+            RETURNING *;
+            """
+        )
+        logger.info(f"Merged {len(deleted_targets):d} targets into TNS targets.")
+        for target in deleted_targets:
+            logger.info(f" - deleted target {target.name} during merge")
+
+        new_targets = Target.objects.raw(
+            """
+            --STEP 4: add all other unmatched TNS transients to the targets table (removing duplicate names)
+            INSERT INTO tom_targets_target (name, type, created, modified, ra, dec, epoch, scheme)
+            SELECT CONCAT(name_prefix, name), 'SIDEREAL', NOW(), NOW(), ra, declination, 2000, ''
+            FROM tns_q3c WHERE name_prefix != 'FRB' AND name != '2023hzc' -- this is a duplicate in the TNS
+            ON CONFLICT (name) DO NOTHING
+            RETURNING *;
+            """
+        )
+        logger.info(f"Added {len(new_targets):d} new targets from the TNS.")
+
+        with connection.cursor() as cursor:
+            cursor.execute("DROP TABLE tns_matches, top_tns_matches, targets_to_merge; -- cleanup")
+
+        for target in updated_targets:
+            target_post_save(target, created=True)
+        for target in new_targets:
+            target_post_save(target, created=True)
+            for galaxy in json.loads(target.targetextra_set.get(key='Host Galaxies').value):
+                if galaxy['Dist'] <= 40.:
+                    slack_alert = (f'<https://sand.as.arizona.edu/saguaro_tom/targets/{target.id}/|{target.name}> is '
+                                   f'{galaxy["Offset"]:.1f}" from galaxy {galaxy["ID"]} at {galaxy["Dist"]:.1f} Mpc')
+                    json_data = json.dumps({'text': slack_alert}).encode('ascii')
+                    requests.post(settings.SLACK_TNS_URL, data=json_data, headers={'Content-Type': 'application/json'})
+                    break

--- a/saguaro_tom/settings_local.template.py
+++ b/saguaro_tom/settings_local.template.py
@@ -30,6 +30,7 @@ SLACK_LINKS = [  # links to TOMs for Slack alerts, {nle.id} is replaced by the e
     '<https://tom0.edu/nonlocalizedevents/{nle.event_id}/|Name of TOM 0>',  # TOM corresponding to Slack workspace 0
     '<https://tom1.edu/nonlocalizedevents/{nle.event_id}/|Name of TOM 1>',  # TOM corresponding to Slack workspace 1
 ]
+SLACK_TNS_URL = 'https://hooks.slack.com/services/.../.../...'  # incoming webhook for TNS transient alerts
 SLACK_URLS = [  # list of lists of Slack URLs for incoming webhooks
     [  # list of URLs for Slack workspace 0
         'https://hooks.slack.com/services/.../.../...',  # incoming webhook for #alerts-subthreshold

--- a/templates/tom_common/navbar_content.html
+++ b/templates/tom_common/navbar_content.html
@@ -23,6 +23,9 @@ For customization instructions, see tom_common/base.html
             <a class="nav-link" href="{% url 'custom_code:candidates' %}?obsdate_range_after={% now 'Y-m-d' %}&classification=0&order=-mlscore_real" style="color:black">Candidates</a>
         </li>
         <li class="nav-item">
+            <a class="nav-link" href="{% url 'custom_code:candidates' %}?target__name__startswith=AT,SN&order=-observation_record__scheduled_start" style="color:black">TNS Transients</a>
+        </li>
+        <li class="nav-item">
             <a class="nav-link" href="{% url 'treasuremap:list' %}" style="color:black">Treasure Map</a>
         </li>
     </ul>

--- a/templates/tom_targets/candidate_list.html
+++ b/templates/tom_targets/candidate_list.html
@@ -42,7 +42,7 @@
         <tr>
           <td>
             {% if candidate.target is not None %}
-              <a href="{% url 'targets:detail' candidate.target.id %}" title="{{ candidate.target.name }}" target="_blank">{{ candidate.target.name|slice:":9" }} {{ candidate.target.name|slice:"9:" }}</a>
+              <a href="{% url 'targets:detail' candidate.target.id %}" title="{{ candidate.target.name }}" target="_blank">{{ candidate.target.name|slice:":9" }}<wbr>{{ candidate.target.name|slice:"9:" }}</a>
             {% else %}
               None
             {% endif %}

--- a/templates/tom_targets/target_list.html
+++ b/templates/tom_targets/target_list.html
@@ -1,0 +1,62 @@
+{% extends 'tom_common/base.html' %}
+{% load bootstrap4 targets_extras dataproduct_extras %}
+{% block title %}Targets{% endblock %}
+{% block content %}
+<div class="row">
+  <div class="col-md-10">
+    <div class="row">
+      <div class="col-md-12">
+        <span class="float-right">
+        {{ target_count }} Targets &nbsp;
+        <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Create Targets
+        </button>
+        <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+          <a class="dropdown-item" href="{% url 'targets:create' %}" title="Create a Target">Create a Target</a>
+          <a class="dropdown-item" href="{% url 'targets:import' %}" title="Import Targets">Import Targets</a>
+          <a class="dropdown-item" href="{% url 'tom_catalogs:query' %}" title="Catalog Search">Catalog Search</a>
+        </div>
+        {% update_broker_data_button %}
+        <button onclick="document.getElementById('invisible-export-button').click()" class="btn btn-primary">Export Filtered Targets</button>
+         <!-- use an invisible button, because the key "Enter" event will triggered the first submit button and we want the default action to be applying filter -->
+      </span>
+      </div>
+    </div>
+    {% select_target_js %}
+    {% bootstrap_pagination page_obj extra=request.GET.urlencode %}
+    <label id="displaySelected"></label>
+    <button id="optionSelectAll" type="button" class="btn btn-link" onClick="select_all({{ target_count }})"></button>
+    <form id="grouping-form" action="{% url 'targets:add-remove-grouping' %}" method="POST">
+      {% csrf_token %}
+      <div class="form-group d-flex justify-content-end align-items-baseline">
+        <label>Add/Remove from grouping</label>
+        <select name="grouping" class="form-control w-25 ml-1">
+          {% for grouping in groupings %}
+          <option value="{{ grouping.id }}">{{ grouping.name }}</option>
+          {% endfor %}
+        </select>
+        <input type="hidden" value="{{ query_string }}" name="query_string">
+        <input type="hidden" value="False" id="isSelectAll" name="isSelectAll">
+        <button type="submit" class="btn btn-outline-primary ml-1" name="add">Add</button>
+        <button type="submit" class="btn btn-outline-primary ml-1" name="move">Move</button>
+        <button type="submit" class="btn btn-outline-danger ml-1" name="remove">Remove</button>
+      </div>
+      {% target_table object_list %}
+    </form>
+    {% bootstrap_pagination page_obj extra=request.GET.urlencode %}
+  </div>
+  {{ filter.fields }}
+  <div class="col-md-2">
+    <form action="" method="get" class="form">
+      {% bootstrap_form filter.form %}
+      {% buttons %}
+        <button type="submit" class="btn btn-primary">
+          Filter
+        </button>
+        <a href="{% url 'targets:list' %}" class="btn btn-secondary" title="Reset">Reset</a>
+        <button type="submit" formaction="{% url 'targets:export' %}" id="invisible-export-button" style="display:none"></button>
+      {% endbuttons %}
+    </form>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This adds the capability to regularly ingest all TNS transients into the TOM via the `ingest_tns` management command. It also removes the skymap from the target list page, which is too slow for a target list that contains all TNS transients, and it adds the ability to filter the candidates page by name, with a shortcut to display all the TNS transients. Lastly it adds minimal infrastructure to send Slack alerts based on specific criteria applied to newly ingested TNS transients.