### PR TITLE
Broker links

### DIFF
--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -2,7 +2,7 @@ import logging
 from kne_cand_vetting.catalogs import static_cats_query
 from kne_cand_vetting.galaxy_matching import galaxy_search
 from kne_cand_vetting.survey_phot import query_TNSphot, query_ZTFpubphot
-from tom_targets.models import TargetExtra
+from tom_targets.models import TargetExtra, TargetName
 from tom_dataproducts.models import ReducedDatum
 import json
 import numpy as np
@@ -43,6 +43,9 @@ def process_reduced_ztf_data(target, candidates):
             source_location=candidate['zid'],
             data_type='photometry',
             target=target)
+        tn, created = TargetName.objects.get_or_create(target=target, name=candidate['oid'])
+        if created:
+            logger.info(f'added alias {tn.name} to target {target.name}')
 
 
 def update_or_create_target_extra(target, key, value):

--- a/templates/tom_targets/partials/target_data.html
+++ b/templates/tom_targets/partials/target_data.html
@@ -8,14 +8,16 @@
     {% endif %}
     <dd class="col-sm-9">
         {{ target_name }}
-        {% if target_name|slice:":2" == "AT" or target_name|slice:":2" == "SN" %}
+        {% with target_name|slice:":3" as prefix %}
+        {% if prefix == "AT1" or prefix == "AT2" or prefix == "SN1" or prefix == "SN2" %}
             <a href="https://www.wis-tns.org/object/{{ target_name|slice:"2:" }}" target="_blank"><img src="https://www.wis-tns.org/sites/default/files/favicon.png" alt="TNS" title="TNS" style="height: 1em;"></a>
-        {% elif target_name|slice:":3" == 'ZTF' %}
+        {% elif prefix == "ZTF" %}
             <a href="https://alerce.online/object/{{ target_name }}" target="_blank"><img src="https://alerce.online/favicon.ico" alt="ALeRCE" title="ALeRCE" style="height: 1em;"></a>
             <a href="https://antares.noirlab.edu/loci/lookup/{{ target_name }}" target="_blank"><img src="https://antares.noirlab.edu/favicon.ico" alt="ANTARES" title="ANTARES" style="height: 1em;"></a>
             <a href="https://fink-portal.org/{{ target_name }}" target="_blank"><img src="https://fink-portal.org/assets/favicon.ico" alt="Fink" title="Fink" style="height: 1em;"></a>
             <a href="https://lasair-ztf.lsst.ac.uk/objects/{{ target_name }}/" target="_blank"><img src="https://lasair-ztf.lsst.ac.uk/lasair/static/img/favicon/favicon.ico" alt="Lasair" title="Lasair" style="height: 1em;"></a>
         {% endif %}
+        {% endwith %}
     </dd>
   {% endfor %}
   {% for event_candidate in target.eventcandidate_set.all %}

--- a/templates/tom_targets/partials/target_data.html
+++ b/templates/tom_targets/partials/target_data.html
@@ -6,11 +6,17 @@
     {% else %}
       <dt class="col-sm-3">&nbsp;</dt>
     {% endif %}
-    {% if target_name|slice:":2" == "AT" or target_name|slice:":2" == "SN" %}
-      <dd class="col-sm-9"><a href="https://www.wis-tns.org/object/{{ target_name|slice:"2:" }}" target="_blank">{{ target_name }}</a></dd>
-    {% else %}
-      <dd class="col-sm-9">{{ target_name }}</dd>
-    {% endif %}
+    <dd class="col-sm-9">
+        {{ target_name }}
+        {% if target_name|slice:":2" == "AT" or target_name|slice:":2" == "SN" %}
+            <a href="https://www.wis-tns.org/object/{{ target_name|slice:"2:" }}" target="_blank"><img src="https://www.wis-tns.org/sites/default/files/favicon.png" alt="TNS" title="TNS" style="height: 1em;"></a>
+        {% elif target_name|slice:":3" == 'ZTF' %}
+            <a href="https://alerce.online/object/{{ target_name }}" target="_blank"><img src="https://alerce.online/favicon.ico" alt="ALeRCE" title="ALeRCE" style="height: 1em;"></a>
+            <a href="https://antares.noirlab.edu/loci/lookup/{{ target_name }}" target="_blank"><img src="https://antares.noirlab.edu/favicon.ico" alt="ANTARES" title="ANTARES" style="height: 1em;"></a>
+            <a href="https://fink-portal.org/{{ target_name }}" target="_blank"><img src="https://fink-portal.org/assets/favicon.ico" alt="Fink" title="Fink" style="height: 1em;"></a>
+            <a href="https://lasair-ztf.lsst.ac.uk/objects/{{ target_name }}/" target="_blank"><img src="https://lasair-ztf.lsst.ac.uk/lasair/static/img/favicon/favicon.ico" alt="Lasair" title="Lasair" style="height: 1em;"></a>
+        {% endif %}
+    </dd>
   {% endfor %}
   {% for event_candidate in target.eventcandidate_set.all %}
     <dt class="col-sm-3">&nbsp;</dt>


### PR DESCRIPTION
Resolves #91 by adding any ZTF name as an alias during the vetting procedure, and then displaying links to various brokers next to that name on the target detail page.