### PR TITLE
EventCandidates from TNS

### DIFF
--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -83,7 +83,7 @@ def send_text(body, is_test_alert=False, is_significant=True, is_burst=False, ha
             twilio_client.messages.create(body=body_ascii, from_=settings.ALERT_SMS_FROM, to=user.phone_number.as_e164)
 
 
-def send_slack(body, nle, is_test_alert=False, is_significant=True, is_burst=False, has_ns=True):
+def send_slack(body, nle, is_test_alert=False, is_significant=True, is_burst=False, has_ns=True, all_workspaces=True):
     if is_test_alert:
         return
     elif not is_significant:
@@ -100,6 +100,8 @@ def send_slack(body, nle, is_test_alert=False, is_significant=True, is_burst=Fal
         body_slack = body.replace(ALERT_TEXT_URL.format(nle=nle), ALERT_LINKS.format(link=link).format(nle=nle))
         json_data = json.dumps({'text': body_slack})
         requests.post(url_list[channel], data=json_data.encode('ascii'), headers=headers)
+        if not all_workspaces:
+            break
 
 
 def send_email(subject, body, is_test_alert=False):

--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -20,53 +20,53 @@ logger = logging.getLogger(__name__)
 
 twilio_client = Client(settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN)
 
-ALERT_TEXT_INTRO = """{most_likely_class} {seq.event_subtype} v{seq.sequence_id}
-{nle.event_id} ({significance})
-{time}
-1/FAR = {inverse_far}
+ALERT_TEXT_INTRO = """{{most_likely_class}} {{seq.event_subtype}} v{{seq.sequence_id}}
+{{nle.event_id}} ({{significance}})
+{{time}}
+1/FAR = {{inverse_far}}
 """
 
-ALERT_TEXT_LOCALIZATION = """Distance = {distance}
-50% Area = {seq.localization.area_50:.0f} deg²
-90% Area = {seq.localization.area_90:.0f} deg²
+ALERT_TEXT_LOCALIZATION = """Distance = {{distance}}
+50% Area = {{seq.localization.area_50:.0f}} deg²
+90% Area = {{seq.localization.area_90:.0f}} deg²
 """
 
-ALERT_TEXT_EXTERNAL_COINCIDENCE = """Distance (comb.) = {distance_external}
-50% Area (comb.) = {seq.external_coincidence.localization.area_50:.0f} deg²
-90% Area (comb.) = {seq.external_coincidence.localization.area_90:.0f} deg²
+ALERT_TEXT_EXTERNAL_COINCIDENCE = """Distance (comb.) = {{distance_external}}
+50% Area (comb.) = {{seq.external_coincidence.localization.area_50:.0f}} deg²
+90% Area (comb.) = {{seq.external_coincidence.localization.area_90:.0f}} deg²
 """
 
-ALERT_TEXT_CLASSIFICATION = """Has NS = {HasNS:.0%}
-Has Mass Gap = {HasMassGap:.0%}
-Has Remnant = {HasRemnant:.0%}
-BNS = {BNS:.0%}
-NSBH = {NSBH:.0%}
-BBH = {BBH:.0%}
-Terrestrial = {Terrestrial:.0%}
+ALERT_TEXT_CLASSIFICATION = """Has NS = {{HasNS:.0%}}
+Has Mass Gap = {{HasMassGap:.0%}}
+Has Remnant = {{HasRemnant:.0%}}
+BNS = {{BNS:.0%}}
+NSBH = {{NSBH:.0%}}
+BBH = {{BBH:.0%}}
+Terrestrial = {{Terrestrial:.0%}}
 """
 
-ALERT_TEXT_URL = "https://sand.as.arizona.edu/saguaro_tom/nonlocalizedevents/{nle.event_id}/"
+# links for Slack
+ALERT_LINKS = ('<{link}|{service}> <{{nle.hermes_url}}|Hermes> '
+               '<{{nle.gracedb_url}}|GraceDB> <{{nle.treasuremap_url}}|Treasure Map>')
 
-ALERT_TEXT_RETRACTION = "{most_likely_class} {nle.event_id} {nle.state}"
+ALERT_TEXT_RETRACTION = "{{most_likely_class}} {{nle.event_id}} {{nle.state}}"
 
-ALERT_TEXT_BURST = ALERT_TEXT_INTRO + """50% Area = {seq.localization.area_50:.0f} deg²
-90% Area = {seq.localization.area_90:.0f} deg²
-Duration = {duration_ms:.0f} ms
-Frequency = {central_frequency:.0f} Hz
-""" + ALERT_TEXT_URL
+ALERT_TEXT_BURST = ALERT_TEXT_INTRO + """50% Area = {{seq.localization.area_50:.0f}} deg²
+90% Area = {{seq.localization.area_90:.0f}} deg²
+Duration = {{duration_ms:.0f}} ms
+Frequency = {{central_frequency:.0f}} Hz
+""" + ALERT_LINKS
 
 ALERT_TEXT = [  # index = number of localizations available
-    ALERT_TEXT_INTRO + ALERT_TEXT_CLASSIFICATION + ALERT_TEXT_URL,
-    ALERT_TEXT_INTRO + ALERT_TEXT_LOCALIZATION + ALERT_TEXT_CLASSIFICATION + ALERT_TEXT_URL,
+    ALERT_TEXT_INTRO + ALERT_TEXT_CLASSIFICATION + ALERT_LINKS,
+    ALERT_TEXT_INTRO + ALERT_TEXT_LOCALIZATION + ALERT_TEXT_CLASSIFICATION + ALERT_LINKS,
     ALERT_TEXT_INTRO + ALERT_TEXT_LOCALIZATION + ALERT_TEXT_EXTERNAL_COINCIDENCE + ALERT_TEXT_CLASSIFICATION +
-    ALERT_TEXT_URL,
+    ALERT_LINKS,
 ]
-
-# links for Slack; replaces ALERT_TEXT_URL
-ALERT_LINKS = '{link} <{{nle.hermes_url}}|Hermes> <{{nle.gracedb_url}}|GraceDB> <{{nle.treasuremap_url}}|Treasure Map>'
 
 
 def send_text(body, is_test_alert=False, is_significant=True, is_burst=False, has_ns=True):
+    """This doesn't currently work"""
     body_ascii = body.replace('±', '+/-').replace('²', '2')
     for user in Profile.objects.all():
         if is_test_alert:
@@ -83,7 +83,7 @@ def send_text(body, is_test_alert=False, is_significant=True, is_burst=False, ha
             twilio_client.messages.create(body=body_ascii, from_=settings.ALERT_SMS_FROM, to=user.phone_number.as_e164)
 
 
-def send_slack(body, nle, is_test_alert=False, is_significant=True, is_burst=False, has_ns=True, all_workspaces=True):
+def send_slack(body, format_kwargs, is_test_alert=False, is_significant=True, is_burst=False, has_ns=True, all_workspaces=True):
     if is_test_alert:
         return
     elif not is_significant:
@@ -96,15 +96,17 @@ def send_slack(body, nle, is_test_alert=False, is_significant=True, is_burst=Fal
         channel = 3
         body = ('<!here>\n' if 'RETRACTED' in body else '<!channel>\n') + body
     headers = {'Content-Type': 'application/json'}
-    for url_list, link in zip(settings.SLACK_URLS, settings.SLACK_LINKS):
-        body_slack = body.replace(ALERT_TEXT_URL.format(nle=nle), ALERT_LINKS.format(link=link).format(nle=nle))
+    for url_list, (link, service) in zip(settings.SLACK_URLS, settings.SLACK_LINKS):
+        body_slack = body.format(link=link, service=service).format(**format_kwargs)
+        logger.info(f'Sending GW alert: {body_slack}')
         json_data = json.dumps({'text': body_slack})
-        requests.post(url_list[channel], data=json_data.encode('ascii'), headers=headers)
+        # requests.post(url_list[channel], data=json_data.encode('ascii'), headers=headers)
         if not all_workspaces:
             break
 
 
 def send_email(subject, body, is_test_alert=False):
+    """This doesn't currently work"""
     msg = MIMEText(body)
     msg['Subject'] = subject
     msg['From'] = settings.ALERT_EMAIL_FROM
@@ -157,6 +159,51 @@ def pick_slack_channel(seq):
     return is_test_alert, is_significant, is_burst, has_ns
 
 
+def prepare_and_send_alerts(nle, seq):
+    localizations = []
+    try:
+        if seq is None:  # retraction
+            seq = nle.sequences.last()
+        else:
+            if seq.localization is not None:
+                localizations.append(seq.localization)
+            if seq.external_coincidence is not None and seq.external_coincidence.localization is not None:
+                localizations.append(seq.external_coincidence.localization)
+        is_test_alert, is_significant, is_burst, has_ns = pick_slack_channel(seq)
+        format_kwargs = {
+            'nle': nle,
+            'seq': seq,
+            'most_likely_class': get_most_likely_class(seq.details),
+            'inverse_far': format_inverse_far(seq.details['far']),
+            'significance': 'significant' if is_significant else 'subthreshold',
+        }
+        if nle.state == 'RETRACTED':
+            alert_text = ALERT_TEXT_RETRACTION
+        elif is_burst:
+            alert_text = ALERT_TEXT_BURST
+            format_kwargs['duration_ms'] = seq.details['duration'] * 1000.
+        else:
+            alert_text = ALERT_TEXT[len(localizations)]
+            if localizations:
+                format_kwargs['distance'] = format_distance(localizations[0])
+            if len(localizations) > 1:
+                format_kwargs['distance_external'] = format_distance(localizations[1])
+        format_kwargs.update(seq.details['properties'])
+        format_kwargs.update(seq.details['classification'])
+        format_kwargs.update(seq.details)
+    except Exception as e:
+        logger.error(f'Could not parse GW alert: {e}')
+        alert_text = f'Received a GW alert that could not be parsed. Check GraceDB: {nle.gracedb_url}'
+        format_kwargs = {}
+        is_test_alert = nle.event_id.startswith('M')
+        is_significant = False
+        is_burst = False
+        has_ns = False
+    send_slack(alert_text, format_kwargs,
+               is_test_alert=is_test_alert, is_significant=is_significant, is_burst=is_burst, has_ns=has_ns)
+    return localizations
+
+
 def handle_message_and_send_alerts(message, metadata):
     # get skymap bytes out for later
     try:
@@ -173,46 +220,7 @@ def handle_message_and_send_alerts(message, metadata):
         logger.info('Test alert not saved')
         return
 
-    # send SMS, Slack, and email alerts
-    email_subject = nle.event_id
-    localizations = []
-    try:
-        if seq is None:  # retraction
-            seq = nle.sequences.last()
-        else:
-            if seq.localization is not None:
-                localizations.append(seq.localization)
-            if seq.external_coincidence is not None and seq.external_coincidence.localization is not None:
-                localizations.append(seq.external_coincidence.localization)
-        is_test_alert, is_significant, is_burst, has_ns = pick_slack_channel(seq)
-        derived_quantities = {
-            'most_likely_class': get_most_likely_class(seq.details),
-            'inverse_far': format_inverse_far(seq.details['far']),
-            'significance': 'significant' if is_significant else 'subthreshold',
-        }
-        if nle.state == 'RETRACTED':
-            alert_text = ALERT_TEXT_RETRACTION
-        elif is_burst:
-            alert_text = ALERT_TEXT_BURST
-            derived_quantities['duration_ms'] = seq.details['duration'] * 1000.
-        else:
-            alert_text = ALERT_TEXT[len(localizations)]
-            if localizations:
-                derived_quantities['distance'] = format_distance(localizations[0])
-            if len(localizations) > 1:
-                derived_quantities['distance_external'] = format_distance(localizations[1])
-        body = alert_text.format(nle=nle, seq=seq, **seq.details, **derived_quantities,
-                                 **seq.details['properties'], **seq.details['classification'])
-        logger.info(f'Sending GW alert: {body}')
-    except Exception as e:
-        logger.error(f'Could not parse GW alert: {e}')
-        body = f'Received a GW alert that could not be parsed. Check GraceDB: {nle.gracedb_url}'
-        is_significant = False
-        is_burst = False
-        has_ns = False
-    # send_text(body, is_test_alert=is_test_alert, is_significant=is_significant, is_burst=is_burst, has_ns=has_ns)
-    send_slack(body, nle, is_test_alert=is_test_alert, is_significant=is_significant, is_burst=is_burst, has_ns=has_ns)
-    # send_email(email_subject, body, is_test_alert=is_test_alert)
+    localizations = prepare_and_send_alerts(nle, seq)
 
     for localization in localizations:
         if CredibleRegionContour.objects.filter(localization=localization).exists():

--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -100,7 +100,7 @@ def send_slack(body, format_kwargs, is_test_alert=False, is_significant=True, is
         body_slack = body.format(link=link, service=service).format(**format_kwargs)
         logger.info(f'Sending GW alert: {body_slack}')
         json_data = json.dumps({'text': body_slack})
-        # requests.post(url_list[channel], data=json_data.encode('ascii'), headers=headers)
+        requests.post(url_list[channel], data=json_data.encode('ascii'), headers=headers)
         if not all_workspaces:
             break
 

--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -46,7 +46,7 @@ Terrestrial = {{Terrestrial:.0%}}
 """
 
 # links for Slack
-ALERT_LINKS = ('<{link}|{service}> <{{nle.hermes_url}}|Hermes> '
+ALERT_LINKS = ('<{nle_link}|{service}> <{{nle.hermes_url}}|Hermes> '
                '<{{nle.gracedb_url}}|GraceDB> <{{nle.treasuremap_url}}|Treasure Map>')
 
 ALERT_TEXT_RETRACTION = "{{most_likely_class}} {{nle.event_id}} {{nle.state}}"
@@ -96,8 +96,8 @@ def send_slack(body, format_kwargs, is_test_alert=False, is_significant=True, is
         channel = 3
         body = ('<!here>\n' if 'RETRACTED' in body else '<!channel>\n') + body
     headers = {'Content-Type': 'application/json'}
-    for url_list, (link, service) in zip(settings.SLACK_URLS, settings.SLACK_LINKS):
-        body_slack = body.format(link=link, service=service).format(**format_kwargs)
+    for url_list, (nle_link, service), (target_link, _) in zip(settings.SLACK_URLS, settings.NLE_LINKS, settings.TARGET_LINKS):
+        body_slack = body.format(nle_link=nle_link, service=service, target_link=target_link).format(**format_kwargs)
         logger.info(f'Sending GW alert: {body_slack}')
         json_data = json.dumps({'text': body_slack})
         requests.post(url_list[channel], data=json_data.encode('ascii'), headers=headers)

--- a/custom_code/healpix_utils.py
+++ b/custom_code/healpix_utils.py
@@ -4,6 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import declarative_base, Session
 from tom_nonlocalizedevents.models import EventCandidate
 from tom_nonlocalizedevents.healpix_utils import sa_engine, SaSkymapTile
+from tom_nonlocalizedevents.healpix_utils import update_all_credible_region_percents_for_candidates
 from tom_surveys.models import SurveyField
 from tom_targets.models import Target
 from .models import SurveyFieldCredibleRegion
@@ -135,4 +136,9 @@ def create_candidates_from_targets(eventsequence, prob=0.95, target_ids=None):
                 new_candidates.append(ec)
 
         logger.info(f'Linked {len(new_candidates)} new candidates to event {eventsequence.nonlocalizedevent.event_id}')
+
+        localizations = eventsequence.nonlocalizedevent.localizations.all()
+        for localization in localizations:
+            update_all_credible_region_percents_for_candidates(localization, [cand.id for cand in new_candidates])
+
         return new_candidates

--- a/custom_code/healpix_utils.py
+++ b/custom_code/healpix_utils.py
@@ -2,8 +2,10 @@ from django.conf import settings
 from healpix_alchemy.types import Point
 import sqlalchemy as sa
 from sqlalchemy.orm import declarative_base, Session
+from tom_nonlocalizedevents.models import EventCandidate
 from tom_nonlocalizedevents.healpix_utils import sa_engine, SaSkymapTile
 from tom_surveys.models import SurveyField
+from tom_targets.models import Target
 from .models import SurveyFieldCredibleRegion
 import json
 import logging
@@ -68,3 +70,69 @@ def update_all_credible_region_percents_for_survey_fields(eventlocalization):
                     }
                 )
     logger.info('Updated credible regions for survey fields')
+
+
+class SaTargetExtra(Base):
+    __tablename__ = 'tom_targets_targetextra'
+    id = sa.Column(sa.Integer, primary_key=True)
+    target_id = sa.Column(sa.Integer, nullable=False)
+    key = sa.Column(sa.String, nullable=False)
+    value = sa.Column(sa.String, nullable=False)
+
+
+def create_candidates_from_targets(eventsequence, prob=0.95, target_ids=None):
+    """
+    Creates an EventCandidate for each target that falls within the `prob` credible region of the localization region
+    associated with `eventsequence`. If no `target_ids` are given, all targets (not starting with "J") created after the
+    event time are considered.
+    """
+    if target_ids is None:
+        targets = Target.objects.exclude(name__startswith='J').filter(created__gte=eventsequence.details['time'])
+        target_ids = list(targets.values_list('pk', flat=True))
+
+    with Session(sa_engine) as session:
+
+        cum_prob = sa.func.sum(
+            SaSkymapTile.probdensity * SaSkymapTile.tile.area
+        ).over(
+            order_by=SaSkymapTile.probdensity.desc()
+        ).label(
+            'cum_prob'
+        )
+
+        subquery = sa.select(
+            SaSkymapTile.probdensity,
+            cum_prob
+        ).filter(
+            SaSkymapTile.localization_id == eventsequence.localization.id
+        ).subquery()
+
+        min_probdensity = sa.select(
+            sa.func.min(subquery.columns.probdensity)
+        ).filter(
+            subquery.columns.cum_prob <= prob
+        ).scalar_subquery()
+
+        query = sa.select(
+            SaTargetExtra.target_id
+        ).filter(
+            SaTargetExtra.target_id.in_(target_ids),
+            SaTargetExtra.key == 'healpix',
+            SaSkymapTile.localization_id == eventsequence.localization.id,
+            SaSkymapTile.tile.contains(sa.cast(SaTargetExtra.value, sa.BigInteger)),
+            SaSkymapTile.probdensity >= min_probdensity
+        )
+
+        results = session.execute(query)
+
+        new_candidates = []
+        for result in results:
+            ec, created = EventCandidate.objects.get_or_create(
+                target=Target.objects.get(id=result[0]),
+                nonlocalizedevent=eventsequence.nonlocalizedevent,
+            )
+            if created:
+                new_candidates.append(ec)
+
+        logger.info(f'Linked {len(new_candidates)} new candidates to event {eventsequence.nonlocalizedevent.event_id}')
+        return new_candidates

--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -9,6 +9,7 @@ import numpy as np
 from astropy.cosmology import FlatLambdaCDM
 from astropy.time import Time, TimezoneInfo
 from astropy.coordinates import SkyCoord
+from healpix_alchemy.constants import HPX
 from django.conf import settings
 
 DB_CONNECT = "postgresql+psycopg2://{USER}:{PASSWORD}@{HOST}:{PORT}/{NAME}".format(**settings.DATABASES['default'])
@@ -65,6 +66,8 @@ def target_post_save(target, created):
         target.galactic_lng = coord.galactic.l.deg
         target.galactic_lat = coord.galactic.b.deg
         target.save()
+
+        update_or_create_target_extra(target=target, key='healpix', value=HPX.skycoord_to_healpix(coord))
 
         qso, qoffset, asassn, asassnoffset, tns_results, gaia, gaiaoffset, gaiaclass, ps1prob, ps1, ps1offset = \
             static_cats_query([target.ra], [target.dec], db_connect=DB_CONNECT)

--- a/custom_code/management/commands/ingest_tns.py
+++ b/custom_code/management/commands/ingest_tns.py
@@ -181,4 +181,4 @@ class Command(BaseCommand):
                                f'{candidate.target.name}> falls in the localization region of '
                                f'<https://sand.as.arizona.edu/saguaro_tom/nonlocalizedevents/{nle.event_id}/|'
                                f'{nle.event_id}>')
-                send_slack(slack_alert, nle, *pick_slack_channel(seq))
+                send_slack(slack_alert, nle, *pick_slack_channel(seq), all_workspaces=False)

--- a/custom_code/management/commands/ingest_tns.py
+++ b/custom_code/management/commands/ingest_tns.py
@@ -177,8 +177,7 @@ class Command(BaseCommand):
             seq = nle.sequences.last()
             candidates = create_candidates_from_targets(seq, target_ids=target_ids)
             for candidate in candidates:
-                slack_alert = (f'<https://sand.as.arizona.edu/saguaro_tom/targets/{candidate.target.id}/|'
-                               f'{candidate.target.name}> falls in the localization region of '
-                               f'<https://sand.as.arizona.edu/saguaro_tom/nonlocalizedevents/{nle.event_id}/|'
-                               f'{nle.event_id}>')
-                send_slack(slack_alert, nle, *pick_slack_channel(seq), all_workspaces=False)
+                format_kwargs = {'nle': nle, 'candidate': candidate}
+                slack_alert = ('<https://sand.as.arizona.edu/saguaro_tom/targets/{{candidate.target.id}}/|{{candidate.target.name}}> '
+                               'falls in the localization region of <{link}|{{nle.event_id}}>')
+                send_slack(slack_alert, format_kwargs, *pick_slack_channel(seq), all_workspaces=False)

--- a/custom_code/management/commands/ingest_tns.py
+++ b/custom_code/management/commands/ingest_tns.py
@@ -172,7 +172,7 @@ class Command(BaseCommand):
 
         # automatically associate with nonlocalized events
         active_nles = get_active_nonlocalizedevents()
-        target_ids = [target.id for target in new_targets + updated_targets]
+        target_ids = [target.id for target in new_targets] + [target.id for target in updated_targets]
         for nle in active_nles:
             seq = nle.sequences.last()
             candidates = create_candidates_from_targets(seq, target_ids=target_ids)

--- a/custom_code/management/commands/ingest_tns.py
+++ b/custom_code/management/commands/ingest_tns.py
@@ -171,7 +171,7 @@ class Command(BaseCommand):
             requests.post(settings.SLACK_TNS_URL, data=json_data, headers={'Content-Type': 'application/json'})
 
         # automatically associate with nonlocalized events
-        active_nles = get_active_nonlocalizedevents()
+        active_nles = get_active_nonlocalizedevents(lookback_days=7.)
         target_ids = [target.id for target in new_targets] + [target.id for target in updated_targets]
         for nle in active_nles:
             seq = nle.sequences.last()

--- a/custom_code/management/commands/ingest_tns.py
+++ b/custom_code/management/commands/ingest_tns.py
@@ -148,8 +148,8 @@ class Command(BaseCommand):
             # check if any of the possible host galaxies are within 40 Mpc
             for galaxy in json.loads(target.targetextra_set.get(key='Host Galaxies').value):
                 if galaxy['Source'] in ['GLADE', 'GWGC', 'HECATE'] and galaxy['Dist'] <= 40.:  # catalogs that have dist
-                    slack_alert = (f'<https://sand.as.arizona.edu/saguaro_tom/targets/{target.id}/|{target.name}> is '
-                                   f'{galaxy["Offset"]:.1f}" from galaxy {galaxy["ID"]} at {galaxy["Dist"]:.1f} Mpc.')
+                    slack_alert = (f'<{settings.TARGET_LINKS[0][0]}/|{target.name}> is {galaxy["Offset"]:.1f}" from '
+                                   f'galaxy {galaxy["ID"]} at {galaxy["Dist"]:.1f} Mpc.').format(target=target)
                     break
             else:
                 continue
@@ -177,7 +177,7 @@ class Command(BaseCommand):
             seq = nle.sequences.last()
             candidates = create_candidates_from_targets(seq, target_ids=target_ids)
             for candidate in candidates:
-                format_kwargs = {'nle': nle, 'candidate': candidate}
-                slack_alert = ('<https://sand.as.arizona.edu/saguaro_tom/targets/{{candidate.target.id}}/|{{candidate.target.name}}> '
-                               'falls in the localization region of <{link}|{{nle.event_id}}>')
-                send_slack(slack_alert, format_kwargs, *pick_slack_channel(seq), all_workspaces=False)
+                format_kwargs = {'nle': nle, 'target': candidate.target}
+                slack_alert = ('<{target_link}|{{target.name}}> falls in the '
+                               'localization region of <{nle_link}|{{nle.event_id}}>')
+                send_slack(slack_alert, format_kwargs, *pick_slack_channel(seq))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ django-extensions
 django-filter
 django-guardian
 django-phonenumber-field[phonenumberslite]
+healpix-alchemy
 healpy
 kne-cand-vetting @ git+https://github.com/SAGUARO-MMA/kne-cand-vetting
 lightcurve-fitting

--- a/saguaro_tom/settings_local.template.py
+++ b/saguaro_tom/settings_local.template.py
@@ -27,8 +27,8 @@ SCIMMA_AUTH_USERNAME = '' # username for SCIMMA authentication
 SCIMMA_AUTH_PASSWORD = '' # password for SCIMMA authentication
 SECRET_KEY = ''         # see https://docs.djangoproject.com/en/4.1/ref/settings/#secret-key
 SLACK_LINKS = [  # links to TOMs for Slack alerts, {nle.id} is replaced by the event name (e.g., S190425z)
-    '<https://tom0.edu/nonlocalizedevents/{nle.event_id}/|Name of TOM 0>',  # TOM corresponding to Slack workspace 0
-    '<https://tom1.edu/nonlocalizedevents/{nle.event_id}/|Name of TOM 1>',  # TOM corresponding to Slack workspace 1
+    ('https://tom0.edu/nonlocalizedevents/{nle.event_id}/', 'Name of TOM 0'),  # TOM corresponding to Slack workspace 0
+    ('https://tom1.edu/nonlocalizedevents/{nle.event_id}/', 'Name of TOM 1'),  # TOM corresponding to Slack workspace 1
 ]
 SLACK_TNS_URL = 'https://hooks.slack.com/services/.../.../...'  # incoming webhook for TNS transient alerts
 SLACK_URLS = [  # list of lists of Slack URLs for incoming webhooks

--- a/saguaro_tom/settings_local.template.py
+++ b/saguaro_tom/settings_local.template.py
@@ -26,9 +26,13 @@ SAVE_TEST_ALERTS = False # save test gravitational-wave alerts
 SCIMMA_AUTH_USERNAME = '' # username for SCIMMA authentication
 SCIMMA_AUTH_PASSWORD = '' # password for SCIMMA authentication
 SECRET_KEY = ''         # see https://docs.djangoproject.com/en/4.1/ref/settings/#secret-key
-SLACK_LINKS = [  # links to TOMs for Slack alerts, {nle.id} is replaced by the event name (e.g., S190425z)
+NLE_LINKS = [  # links to TOMs for GW event pages, {nle.event_id} is replaced by the event name (e.g., S190425z)
     ('https://tom0.edu/nonlocalizedevents/{nle.event_id}/', 'Name of TOM 0'),  # TOM corresponding to Slack workspace 0
     ('https://tom1.edu/nonlocalizedevents/{nle.event_id}/', 'Name of TOM 1'),  # TOM corresponding to Slack workspace 1
+]
+TARGET_LINKS = [  # links to TOMs for target pages, {target.name} is replaced by the target name (e.g., AT2017gfo)
+    ('https://tom0.edu/targets/{target.id}/', 'Name of TOM 0'),  # TOM corresponding to Slack workspace 0
+    ('https://tom1.edu/targets/{target.name}/', 'Name of TOM 1'),  # TOM corresponding to Slack workspace 1
 ]
 SLACK_TNS_URL = 'https://hooks.slack.com/services/.../.../...'  # incoming webhook for TNS transient alerts
 SLACK_URLS = [  # list of lists of Slack URLs for incoming webhooks

--- a/templates/tom_targets/partials/target_data.html
+++ b/templates/tom_targets/partials/target_data.html
@@ -52,7 +52,7 @@
 <h4>Point Source Matches</h4>
 <dl class="row">
 {% for key, value in target.tags.items %}
-{% if key|slice:':4' != 'Host' and key|slice:':4' != 'Best' %}
+{% if key|slice:':4' != 'Host' and key|slice:':4' != 'Best' and key != 'healpix' %}
 <dt class="col-sm-6">{{ key }}</dt>
     {% if key|slice:'-6:' == 'Offset' %}
         <dd class="col-sm-6">{{ value|floatformat:1 }}"</dd>


### PR DESCRIPTION
This automatically associates newly ingested TNS transients with any relevant NonLocalizedEvents.

EventCandidates generated in this way are posted to Slack. (This required a major refactor of the Slack alert function.)