### PR TITLE
Fix various failure modes in TNS transient ingestion

### DIFF
--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -72,8 +72,10 @@ def target_post_save(target, created):
         qso, qoffset, asassn, asassnoffset, tns_results, gaia, gaiaoffset, gaiaclass, ps1prob, ps1, ps1offset = \
             static_cats_query([target.ra], [target.dec], db_connect=DB_CONNECT)
 
-        if tns_results[0] is not None:
-            iau_name, redshift, classification, internal_names = tns_results[0]
+        if tns_results:
+            for iau_name, redshift, classification, internal_names in tns_results:
+                if target.name[2:] == iau_name[2:]:  # choose the name that already matches, if more than one
+                    break
             if target.name != iau_name:
                 target.name = iau_name
                 target.save()

--- a/custom_code/management/commands/ingest_tns.py
+++ b/custom_code/management/commands/ingest_tns.py
@@ -19,7 +19,6 @@ class Command(BaseCommand):
     help = 'Updates, merges, and adds targets from the tns_q3c table (maintained outside the TOM Toolkit)'
 
     def handle(self, **kwargs):
-        logger.info('Crossmatching TNS with targets table. This will take several minutes.')
 
         updated_targets_coords = Target.objects.raw(
             """
@@ -33,6 +32,7 @@ class Command(BaseCommand):
         )
         logger.info(f"Updated coordinates of {len(updated_targets_coords):d} targets to match the TNS.")
 
+        logger.info('Crossmatching TNS with targets table. This will take several minutes.')
         with connection.cursor() as cursor:
             cursor.execute(
                 """

--- a/custom_code/management/commands/ingest_tns.py
+++ b/custom_code/management/commands/ingest_tns.py
@@ -150,7 +150,10 @@ class Command(BaseCommand):
         )
         logger.info(f"Added {len(new_targets):d} new targets from the TNS.")
 
-        for target in updated_targets.union(updated_targets_coords):
+        for target in updated_targets_coords:
+            target_post_save(target, created=True)
+
+        for target in updated_targets:
             target_post_save(target, created=True)
 
         for target in new_targets:


### PR DESCRIPTION
- adjust coordinates of TNS transients that are more than 2" from their original position
- correctly match TNS transients with another TNS transient within 2" of its position
- use temporary tables to avoid crashing after previous failures