### PR TITLE
Update the `requirements.txt` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ sudo nohup python manage.py readstreams > /home/saguaro/alertstreams.log 2>&1 &
 ## Allowing for asynchronous tasks
 We use [redis](https://redis.io) and [dramatiq](https://dramatiq.io) to run asynchronous tasks (e.g., ATLAS forced photometry queries).
 Redis is installed according to the instructions on its [readme](https://github.com/redis/redis).
-Dramatiq is configured according to the [TOM Toolkit documentation](https://tom-toolkit.readthedocs.io/en/stable/managing_data/forced_photometry.html#configuring-your-tom-to-serve-tasks-asynchronously).
+Dramatiq is configured according to the [TOM Toolkit documentation](https://tom-toolkit.readthedocs.io/en/stable/managing_data/single_target_data_service.html#configuring-your-tom-to-serve-tasks-asynchronously).
 These should automatically restart when `sand` restarts, thanks to this cronjob (run as root):
 ```
 @reboot /usr/local/bin/redis-server > /home/saguaro/redis.log 2>&1

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Welcome to the SAGUARO target and observation manager for GW follow-up.
 
   ```bash
     % cd /var/www/saguaro_tom
+    % python3 manage.py collectstatic # only the first time you start the development server
     % python3 manage.py runserver
   ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,8 @@ numpy
 tomtoolkit==2.18.2
 tom-alertstreams
 tom-mmt @ git+https://github.com/griffin-h/tom_mmt
-tom-nonlocalizedevents @ git+https://github.com/TOMToolkit/tom_nonlocalizedevents.git@fix/bump_dependencies_to_be_compatible_with_tom_base
-tom-swift~=0.2.0
+tom-nonlocalizedevents==0.8.1
+tom-swift==0.2.0
 twilio
 paramiko
 plotly

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,18 +7,18 @@ django-extensions
 django-filter
 django-guardian
 django-phonenumber-field[phonenumberslite]
+dramatiq[watch, redis]
 healpix-alchemy
 healpy
 kne-cand-vetting @ git+https://github.com/SAGUARO-MMA/kne-cand-vetting
 lightcurve-fitting
 ligo.skymap
 numpy
-redis
-tomtoolkit~=2.14
-tom-alertstreams>=0.6.2
+tomtoolkit~=2.18.2
+tom-alertstreams
 tom-mmt @ git+https://github.com/griffin-h/tom_mmt
-tom-nonlocalizedevents~=0.7.7
-tom-swift~=0.2.0a3
+tom-nonlocalizedevents @ git+https://github.com/griffin-h/tom_nonlocalizedevents.git
+tom-swift~=0.2.0
 twilio
 paramiko
 plotly

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ astroplan
 astropy
 django
 django-crispy-forms
+django-dramatiq
 django-extensions
 django-filter
 django-guardian
@@ -12,11 +13,12 @@ kne-cand-vetting @ git+https://github.com/SAGUARO-MMA/kne-cand-vetting
 lightcurve-fitting
 ligo.skymap
 numpy
-tomtoolkit~=2.18.2
-tom-alertstreams
-tom-mmt~=0.1.3
+redis
+tomtoolkit~=2.14
+tom-alertstreams>=0.6.2
+tom-mmt @ git+https://github.com/griffin-h/tom_mmt
 tom-nonlocalizedevents~=0.7.7
-tom-swift~=0.2.0
+tom-swift~=0.2.0a3
 twilio
 paramiko
 plotly

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ numpy
 tomtoolkit~=2.18.2
 tom-alertstreams
 tom-mmt @ git+https://github.com/griffin-h/tom_mmt
-tom-nonlocalizedevents @ git+https://github.com/griffin-h/tom_nonlocalizedevents.git
+tom-nonlocalizedevents @ git+https://github.com/TOMToolkit/tom_nonlocalizedevents.git@fix/bump_dependencies_to_be_compatible_with_tom_base
 tom-swift~=0.2.0
 twilio
 paramiko

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ kne-cand-vetting @ git+https://github.com/SAGUARO-MMA/kne-cand-vetting
 lightcurve-fitting
 ligo.skymap
 numpy
-tomtoolkit~=2.18.2
+tomtoolkit==2.18.2
 tom-alertstreams
 tom-mmt @ git+https://github.com/griffin-h/tom_mmt
 tom-nonlocalizedevents @ git+https://github.com/TOMToolkit/tom_nonlocalizedevents.git@fix/bump_dependencies_to_be_compatible_with_tom_base


### PR DESCRIPTION
A lot of the requirements were broken, there were a lot of conflicts. Some of the notable changes that may break things:
1. Downgraded the tomtoolkit requirement to 2.14
2. Upgraded the tom-alertstreams requirement
3. Downgraded the tom-swift requirement to an alpha release
I had to do this because of [this known issue](https://github.com/TOMToolkit/tom_nonlocalizedevents/issues/37) with the tom-nonlocalizedevents package that makes it incompatible with the current tomtoolkit version.

This is discussed briefly in Issue #99 and unfortunately the only solution I found is downgrading the tom-swift package to an alpha version. This is obviously not ideal but I think it works for now until they fix the issue with the tom-nonlocalizedevents package.