### PR TITLE
Indicate nondetections of targets in CSS observations

### DIFF
--- a/custom_code/templatetags/target_list_extras.py
+++ b/custom_code/templatetags/target_list_extras.py
@@ -2,6 +2,10 @@ from django import template
 from ..models import Candidate, TargetListExtra
 from tom_targets.models import TargetExtra
 from guardian.shortcuts import get_objects_for_user
+from tom_surveys.models import SurveyField, SurveyObservationRecord
+from .skymap_extras import CSS_FOOTPRINT, centers_to_vertices
+import numpy as np
+from matplotlib.path import Path
 import json
 
 register = template.Library()
@@ -31,12 +35,37 @@ def galaxy_table(target):
     return {'galaxies': galaxies}
 
 
+FIELDS = SurveyField.objects.order_by('name')
+CENTERS = np.array(FIELDS.values_list('ra', 'dec'))
+VERTICES = centers_to_vertices(CENTERS, CSS_FOOTPRINT)
+
+
+@register.filter
+def get_survey_observations(target):
+    """
+    Get all survey observations that contain the coordinates of a given target
+    """
+    matching_fields = []
+    for field, vertex in zip(FIELDS, VERTICES):
+        path = Path(vertex)
+        if path.contains_points([[target.ra, target.dec]])[0]:
+            matching_fields.append(field.name)
+    return SurveyObservationRecord.objects.filter(survey_field__name__in=matching_fields)
+
+
 @register.inclusion_tag('tom_targets/partials/candidates_table.html')
 def candidates_table(target):
     """
-    Displays a table of all the candidates (detections) associated with a given target, including thumbnails
+    Displays a table of all the candidates and nondetections associated with a given target, including thumbnails
     """
-    candidates = Candidate.objects.filter(target=target).order_by('-observation_record__scheduled_start')
+    survey_observations = get_survey_observations(target).order_by('-scheduled_start')
+    candidates = []
+    for observation_record in survey_observations:
+        candidate = observation_record.candidate_set.filter(target=target)
+        if candidate.exists():
+            candidates.append(candidate.first())
+        else:
+            candidates.append(Candidate(observation_record=observation_record))  # placeholder for nondetection
     return {'candidates': candidates}
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ healpy
 kne-cand-vetting @ git+https://github.com/SAGUARO-MMA/kne-cand-vetting
 lightcurve-fitting
 ligo.skymap
+matplotlib
 numpy
 tomtoolkit~=2.18.2
 tom-alertstreams

--- a/templates/tom_targets/partials/candidates_table.html
+++ b/templates/tom_targets/partials/candidates_table.html
@@ -18,14 +18,23 @@
     {% for candidate in candidates %}
     <tr>
       <td>{{ candidate.observation_record.scheduled_start|date:"Y-m-d" }}</td>
-      <td>{{ candidate.mag|floatformat:"1" }}</td>
-      <td>{{ candidate.mlscore|floatformat:"2" }}</td>
-      <td>{{ candidate.mlscore_real|floatformat:"2" }}</td>
-      <td>{{ candidate.mlscore_bogus|floatformat:"2" }}</td>
-      <td><img alt="new image" src="{{ candidate|thumbnail_url:'img' }}" height="80"></td>
-      <td><img alt="reference image" src="{{ candidate|thumbnail_url:'ref' }}" height="80"></td>
-      <td><img alt="difference image" src="{{ candidate|thumbnail_url:'diff' }}" height="80"></td>
-      <td><img alt="Scorr image" src="{{ candidate|thumbnail_url:'scorr' }}" height="80"></td>
+      {% if candidate.id %}
+        <td>{{ candidate.mag|floatformat:"1" }}</td>
+        <td>{{ candidate.mlscore|floatformat:"2" }}</td>
+        <td>{{ candidate.mlscore_real|floatformat:"2" }}</td>
+        <td>{{ candidate.mlscore_bogus|floatformat:"2" }}</td>
+        <td><img alt="new image" src="{{ candidate|thumbnail_url:'img' }}" height="80"></td>
+        <td><img alt="reference image" src="{{ candidate|thumbnail_url:'ref' }}" height="80"></td>
+        <td><img alt="difference image" src="{{ candidate|thumbnail_url:'diff' }}" height="80"></td>
+        <td><img alt="Scorr image" src="{{ candidate|thumbnail_url:'scorr' }}" height="80"></td>
+      {% else %}
+        {% if candidate.observation_record.parameters.depth %}
+          <td>&gsim;{{ candidate.observation_record.parameters.depth|floatformat:"1" }}</td>
+        {% else %}
+          <td></td>
+        {% endif %}
+      <td colspan=7 style="horiz-align: center;">No source detected.</td>
+      {% endif %}
     </tr>
     {% empty %}
     <tr><td colspan="8">No candidates yet.</td></tr>


### PR DESCRIPTION
This begins to resolve #98 by adding the CSS nondetections of a target to the table on the candidates tab.