### PR TITLE
automatically plot airmass chart on target detail page

### DIFF
--- a/templates/tom_targets/target_detail.html
+++ b/templates/tom_targets/target_detail.html
@@ -84,7 +84,7 @@
         <hr/>
         <h4>Plan</h4>
         {% if object.type == 'SIDEREAL' %}
-          {% target_plan %}
+          {% target_plan fast_render=True %}
           {% moon_distance object %}
         {% elif target.type == 'NON_SIDEREAL' %}
           <p>Airmass plotting for non-sidereal targets is not currently supported. If you would like to add this functionality, please check out the <a href="https://github.com/TOMToolkit/tom_nonsidereal_airmass" target="_blank">non-sidereal airmass plugin.</a></p>


### PR DESCRIPTION
Resolves #106 by turning on the fast_render option for the target_plan widget.