### PR TITLE
add astroquery for MW E(B-V)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 astroplan
 astropy
+astroquery
 django
 django-crispy-forms
 django-dramatiq

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -336,6 +336,7 @@ HARVESTERS = {
 EXTRA_FIELDS = [
     {'name': 'Classification', 'type': 'string'},
     {'name': 'Redshift', 'type': 'number'},
+    {'name': 'MW E(B-V)', 'type': 'number'},
 ]
 
 # Authentication strategy can either be LOCKED (required login for all views)

--- a/templates/tom_targets/partials/target_data.html
+++ b/templates/tom_targets/partials/target_data.html
@@ -52,7 +52,7 @@
 <h4>Point Source Matches</h4>
 <dl class="row">
 {% for target_extra in target.targetextra_set.all %}
-{% if target_extra.key|slice:':4' != 'Host' and target_extra.key|slice:':4' != 'Best' and target_extra.key != 'healpix' %}
+{% if target_extra.key not in extras and target_extra.key|slice:':4' != 'Host' and target_extra.key != 'healpix' %}
 <dt class="col-sm-6">{{ target_extra.key }}</dt>
     {% if target_extra.key|slice:'-6:' == 'Offset' %}
         <dd class="col-sm-6">{{ target_extra.float_value|floatformat:1 }}"</dd>


### PR DESCRIPTION
Partially resolves #94 by automatically querying IPAC for the Milky Way extinction value during target vetting. This is stored and displayed on the target detail page, but it is not applied to photometry. This would be more complicated because then the TOM would need to know the filter wavelengths and calculate an extinciton law.