### PR TITLE
query live TNS for updated details when vetting

### DIFF
--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -1,7 +1,7 @@
 import logging
 from kne_cand_vetting.catalogs import static_cats_query
 from kne_cand_vetting.galaxy_matching import galaxy_search
-from kne_cand_vetting.survey_phot import query_TNSphot, query_ZTFpubphot
+from kne_cand_vetting.survey_phot import TNS_get, query_ZTFpubphot
 from tom_targets.models import TargetExtra, TargetName
 from tom_dataproducts.models import ReducedDatum
 import json
@@ -90,6 +90,54 @@ def target_post_save(target, created, tns_time_limit:int=5):
             for iau_name, redshift, classification, internal_names in tns_results:
                 if target.name[2:] == iau_name[2:]:  # choose the name that already matches, if more than one
                     break
+
+            # now query the real TNS by name for even more recent updates
+            get_obj = [("objname", iau_name[2:]), ("objid", ""), ("photometry", "1"), ("spectra", "0")]  # remove prefix
+            response, time_to_wait = TNS_get(get_obj,
+                                             settings.BROKERS['TNS']['bot_id'],
+                                             settings.BROKERS['TNS']['bot_name'],
+                                             settings.BROKERS['TNS']['api_key'],
+                                             timelimit=tns_time_limit)
+            if response is not None:
+                tns_reply = response.json()['data']['reply']
+
+                # update the coordinates if needed
+                if target.ra != tns_reply['radeg'] or target.dec != tns_reply['decdeg']:
+                    target.ra = tns_reply['radeg']
+                    target.dec = tns_reply['decdeg']
+                    target.save()
+                    messages.append(f'Updated coordinates to {target.ra:.6f}, {target.dec:.6f} based on TNS')
+
+                # ingest any photometry
+                for candidate in tns_reply['photometry']:
+                    jd = Time(candidate['jd'], format='jd', scale='utc')
+                    value = {'filter': candidate['filters']['name']}
+                    if candidate['flux']:  # detection
+                        value['magnitude'] = candidate['flux']
+                    else:
+                        value['limit'] = candidate['limflux']
+                    if candidate['fluxerr']:  # not empty or zero
+                        value['error'] = candidate['fluxerr']
+                    rd, _ = ReducedDatum.objects.get_or_create(
+                        timestamp=jd.to_datetime(timezone=TimezoneInfo()),
+                        value=value,
+                        source_name=candidate['telescope']['name'] + ' (TNS)',
+                        data_type='photometry',
+                        target=target)
+                    messages.append(f'Added {len(tns_reply["photometry"]):d} photometry points from the TNS')
+
+                # if query is successful, use these up-to-date versions instead of what's in the local copy
+                iau_name = tns_reply['name_prefix'] + tns_reply['objname']
+                redshift = tns_reply['redshift']
+                classification = tns_reply['object_type']['name']
+                internal_names = tns_reply['internal_names']
+
+            else:
+                tns_query_status = f'We ran out of API calls to the TNS with {time_to_wait}s left! This exceeded the {tns_time_limit}s limit!'
+                tns_query_status += f' If it is important that you have all of the photometry we encourage you try again in {time_to_wait}s!'
+                logger.info(tns_query_status)
+
+            # update the target details from the TNS query, if successful, or from the local copy in the database
             if target.name != iau_name:
                 target.name = iau_name
                 target.save()
@@ -106,33 +154,6 @@ def target_post_save(target, created, tns_time_limit:int=5):
                     tn = TargetName.objects.create(target=target, name=alias)
                     messages.append(f'Added alias {tn.name} from TNS')
 
-            tnsphot, time_to_wait = query_TNSphot(target.name[2:],  # remove prefix
-                                    settings.BROKERS['TNS']['bot_id'],
-                                    settings.BROKERS['TNS']['bot_name'],
-                                    settings.BROKERS['TNS']['api_key'],
-                                    timelimit=tns_time_limit)
-
-            if tnsphot is not None:
-                for candidate in tnsphot:
-                    jd = Time(candidate['jd'], format='jd', scale='utc')
-                    value = {'filter': candidate['F']}
-                    if candidate['mag']:  # detection
-                        value['magnitude'] = candidate['mag']
-                    else:
-                        value['limit'] = candidate['limflux']
-                    if candidate['magerr']:  # not empty or zero
-                        value['error'] = candidate['magerr']
-                    rd, _ = ReducedDatum.objects.get_or_create(
-                        timestamp=jd.to_datetime(timezone=TimezoneInfo()),
-                        value=value,
-                        source_name=candidate['tel']+' (TNS)',
-                        data_type='photometry',
-                        target=target)
-            else:
-                tns_query_status = f'We ran out of API calls to the TNS with {time_to_wait}s left! This exceeded the {tns_time_limit}s limit!'
-                tns_query_status += f' If it is important that you have all of the photometry we encourage you try again in {time_to_wait}s!'
-                logger.info(tns_query_status)
-                
         update_or_create_target_extra(target=target, key='QSO Match', value=qso[0])
         if qso[0] != 'None':
             update_or_create_target_extra(target=target, key='QSO Offset', value=qoffset[0])


### PR DESCRIPTION
We previously used our local copy of the TNS for vetting, but then we queried the live TNS to get photometry. This just overrides the names, coordinates, classification, and redshift from our local copy of the TNS with the most up-to-date versions from the live TNS, if available.