### PR TITLE
Add support for Einstein Probe events

### DIFF
--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -295,4 +295,8 @@ def handle_einstein_probe_alert(message, metadata):
             calculate_credible_region(skymap, localization)
             calculate_footprint_probabilities(skymap, localization)
 
-    return nonlocalizedevent, event_sequence
+    slack_alert = f'Received Einstein Probe trigger <{settings.NLE_LINKS[0][0]}|{{nle.event_id}}>'
+    json_data = json.dumps({'text': slack_alert.format(nle=nonlocalizedevent)}).encode('ascii')
+    requests.post(settings.SLACK_EP_URL, data=json_data, headers={'Content-Type': 'application/json'})
+
+    logger.info(f'Finished processing alert for {nonlocalizedevent.event_id}')

--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -217,12 +217,13 @@ def handle_message_and_send_alerts(message, metadata):
     # get skymap bytes out for later
     skymaps = []
     try:
-        event = message.content[0]['event']
+        alert = message.content[0]
+        event = alert.get('event')
         if event is not None:
             skymaps.append(event.get('skymap'))
-            external_coincidence = event.get('external_coincidence')
-            if external_coincidence is not None:
-                skymaps.append(external_coincidence.get('combined_skymap'))
+        external_coinc = alert.get('external_coinc')
+        if external_coinc is not None:
+            skymaps.append(external_coinc.get('combined_skymap'))
     except Exception as e:  # no matter what, do not crash the listener before ingesting the alert
         logger.error(f'Could not extract skymap from alert: {e}')
 

--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -268,12 +268,13 @@ def handle_einstein_probe_alert(message, metadata):
     logger.debug(f"Storing EP alert: {alert}")
 
     # Now ingest the sequence for that event
+    details = {key: alert.get(key) for key in ['image_energy_range', 'net_count_rate', 'image_snr', 'additional_info']}
+    details['time'] = alert.get('trigger_time')  # to match IGWN alerts
     event_sequence, es_created = EventSequence.objects.update_or_create(
         nonlocalizedevent=nonlocalizedevent,
         localization=localization,
         sequence_id=nonlocalizedevent.sequences.count() + 1,
-        details={key: alert.get(key) for key in
-                 ['trigger_time', 'image_energy_range', 'net_count_rate', 'image_snr', 'additional_info']},
+        details=details,
         event_subtype=alert.get('instrument'),
         ingestor_source='hop',
     )

--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -8,7 +8,7 @@ import requests
 import smtplib
 import logging
 import json
-from .templatetags.nonlocalizedevent_extras import format_inverse_far, format_distance, get_most_likely_class
+from .templatetags.nonlocalizedevent_extras import format_inverse_far, format_distance, format_area, get_most_likely_class
 from .healpix_utils import update_all_credible_region_percents_for_survey_fields, create_elliptical_localization
 from .cssfield_selection import calculate_footprint_probabilities
 from .models import CredibleRegionContour, Profile
@@ -29,13 +29,13 @@ ALERT_TEXT_INTRO = """{{most_likely_class}} {{seq.event_subtype}} v{{seq.sequenc
 """
 
 ALERT_TEXT_LOCALIZATION = """Distance = {{distance}}
-50% Area = {{seq.localization.area_50:.0f}} deg²
-90% Area = {{seq.localization.area_90:.0f}} deg²
+50% Area = {{area_50}}
+90% Area = {{area_90}}
 """
 
 ALERT_TEXT_EXTERNAL_COINCIDENCE = """Distance (comb.) = {{distance_external}}
-50% Area (comb.) = {{seq.external_coincidence.localization.area_50:.0f}} deg²
-90% Area (comb.) = {{seq.external_coincidence.localization.area_90:.0f}} deg²
+50% Area (comb.) = {{area_50_external}}
+90% Area (comb.) = {{area_90_external}}
 """
 
 ALERT_TEXT_CLASSIFICATION = """Has NS = {{HasNS:.0%}}
@@ -191,8 +191,12 @@ def prepare_and_send_alerts(nle, seq):
             alert_text = ALERT_TEXT[len(localizations)]
             if localizations:
                 format_kwargs['distance'] = format_distance(localizations[0])
+                format_kwargs['area_50'] = format_area(localizations[0].area_50)
+                format_kwargs['area_90'] = format_area(localizations[0].area_90)
             if len(localizations) > 1:
                 format_kwargs['distance_external'] = format_distance(localizations[1])
+                format_kwargs['area_50_external'] = format_area(localizations[1].area_50)
+                format_kwargs['area_90_external'] = format_area(localizations[1].area_90)
         format_kwargs.update(seq.details['properties'])
         format_kwargs.update(seq.details['classification'])
         format_kwargs.update(seq.details)

--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -291,6 +291,7 @@ def handle_einstein_probe_alert(message, metadata):
     else:
         update_all_credible_region_percents_for_survey_fields(localization)
         if skymap is not None:
+            skymap['PROBDENSITY'].unit = '1 / sr'
             calculate_credible_region(skymap, localization)
             calculate_footprint_probabilities(skymap, localization)
 

--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -147,7 +147,8 @@ def calculate_credible_region(skymap, localization, probability=0.9):
     # Find the pixels included in this sum
     skymap90 = skymap[:index_90].group_by('level')
     credible_region_90 = {str(group['level'][0]): [ipix.item() for ipix in group['ipix']] for group in skymap90.groups}
-    credible_region_90.setdefault(str(skymap.meta['MOCORDER']), [])  # must include the highest order
+    if 'MOCORDER' in skymap.meta:
+        credible_region_90.setdefault(str(skymap.meta['MOCORDER']), [])  # must include the highest order
     # Create the CredibleRegionContour object
     CredibleRegionContour(localization=localization, probability=probability, pixels=credible_region_90).save()
     logger.info('Calculated skymap contours')

--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -249,7 +249,7 @@ def handle_message_and_send_alerts(message, metadata):
 
 
 def handle_einstein_probe_alert(message, metadata):
-    alert = message.content[0]
+    alert = message.content
     logger.warning(f"Handling Einstein Probe alert: {alert}")
 
     nonlocalizedevent, nle_created = NonLocalizedEvent.objects.get_or_create(

--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -270,15 +270,14 @@ def handle_einstein_probe_alert(message, metadata):
     logger.debug(f"Storing EP alert: {alert}")
 
     # Now ingest the sequence for that event
-    details = {key: alert.get(key) for key in ['image_energy_range', 'net_count_rate', 'image_snr', 'additional_info']}
+    details = {key: alert.get(key) for key in
+               ['instrument', 'image_energy_range', 'net_count_rate', 'image_snr', 'additional_info']}
     details['time'] = alert.get('trigger_time')  # to match IGWN alerts
     event_sequence, es_created = EventSequence.objects.update_or_create(
         nonlocalizedevent=nonlocalizedevent,
         localization=localization,
         sequence_id=nonlocalizedevent.sequences.count() + 1,
         details=details,
-        event_subtype=alert.get('instrument'),
-        ingestor_source='hop',
     )
     if es_created and localization is None:
         warning_msg = (

--- a/custom_code/healpix_utils.py
+++ b/custom_code/healpix_utils.py
@@ -9,9 +9,7 @@ from tom_nonlocalizedevents.healpix_utils import sa_engine, SaSkymapTile, uniq_t
 from tom_nonlocalizedevents.healpix_utils import update_all_credible_region_percents_for_candidates
 from tom_surveys.models import SurveyField
 from tom_targets.models import Target
-from .alertstream_handlers import calculate_credible_region
-from .cssfield_selection import calculate_footprint_probabilities
-from .models import SurveyFieldCredibleRegion, CredibleRegionContour
+from .models import SurveyFieldCredibleRegion
 import numpy as np
 from scipy.stats import multivariate_normal
 from ligo.skymap.moc import bayestar_adaptive_grid
@@ -216,11 +214,4 @@ def create_elliptical_localization(nonlocalizedevent, center, radius, conf_inv=0
                     return EventLocalization.objects.get(nonlocalizedevent=nonlocalizedevent, skymap_hash=skymap_hash)
                 raise e
 
-    if CredibleRegionContour.objects.filter(localization=localization).exists():
-        logger.info(f'Localization {localization.id} already exists')
-    else:
-        update_all_credible_region_percents_for_survey_fields(localization)
-        calculate_credible_region(skymap, localization)
-        calculate_footprint_probabilities(skymap, localization)
-
-    return localization
+    return localization, skymap

--- a/custom_code/healpix_utils.py
+++ b/custom_code/healpix_utils.py
@@ -9,7 +9,9 @@ from tom_nonlocalizedevents.healpix_utils import sa_engine, SaSkymapTile, uniq_t
 from tom_nonlocalizedevents.healpix_utils import update_all_credible_region_percents_for_candidates
 from tom_surveys.models import SurveyField
 from tom_targets.models import Target
-from .models import SurveyFieldCredibleRegion
+from .alertstream_handlers import calculate_credible_region
+from .cssfield_selection import calculate_footprint_probabilities
+from .models import SurveyFieldCredibleRegion, CredibleRegionContour
 import numpy as np
 from scipy.stats import multivariate_normal
 from ligo.skymap.moc import bayestar_adaptive_grid
@@ -213,4 +215,12 @@ def create_elliptical_localization(nonlocalizedevent, center, radius, conf_inv=0
                 if 'unique constraint' in e.message:
                     return EventLocalization.objects.get(nonlocalizedevent=nonlocalizedevent, skymap_hash=skymap_hash)
                 raise e
+
+    if CredibleRegionContour.objects.filter(localization=localization).exists():
+        logger.info(f'Localization {localization.id} already exists')
+    else:
+        update_all_credible_region_percents_for_survey_fields(localization)
+        calculate_credible_region(skymap, localization)
+        calculate_footprint_probabilities(skymap, localization)
+
     return localization

--- a/custom_code/templatetags/nonlocalizedevent_extras.py
+++ b/custom_code/templatetags/nonlocalizedevent_extras.py
@@ -10,6 +10,8 @@ SI_PREFIXES = ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y', 'R', 'Q']
 
 @register.filter
 def format_inverse_far(far):
+    if not far:
+        return ''
     inv_far = 3.168808781402895e-08 / far  # 1/Hz to yr
     if inv_far > 1.:
         log1000 = math.log10(inv_far) / 3.

--- a/custom_code/templatetags/nonlocalizedevent_extras.py
+++ b/custom_code/templatetags/nonlocalizedevent_extras.py
@@ -1,6 +1,7 @@
 from django import template
 from django.db.models import Max
 from tom_nonlocalizedevents.models import NonLocalizedEvent
+from custom_code.templatetags.skymap_extras import get_preferred_localization
 import math
 
 register = template.Library()
@@ -108,6 +109,7 @@ def nonlocalizedevent_details(context, localization=None):
             return
         nle = NonLocalizedEvent.objects.get(event_id=event_id)
         sequence = nle.sequences.last()
+        localization = get_preferred_localization(nle)
     elif localization.external_coincidences.exists():
         sequence = localization.external_coincidences.last().sequences.last()
     else:
@@ -119,12 +121,12 @@ def nonlocalizedevent_details(context, localization=None):
                 [
                     ('Event Type', f'{sequence.nonlocalizedevent.event_type} {sequence.details["group"]}'),
                     ('Instrument', '+'.join(sequence.details['instruments'])),
-                    ('50% Area', format_area(sequence.localization.area_50)),
-                    ('90% Area', format_area(sequence.localization.area_90)),
+                    ('50% Area', format_area(localization.area_50)),
+                    ('90% Area', format_area(localization.area_90)),
                 ],
                 [
                     ('1/FAR', format_inverse_far(sequence.details['far'])),
-                    ('Distance', format_distance(sequence.localization)),
+                    ('Distance', format_distance(localization)),
                 ] +
                 [(prop, f'{prob:.0%}') for prop, prob in sequence.details['properties'].items()],
                 [(classification, f'{prob:.0%}') for classification, prob in sequence.details['classification'].items()],
@@ -134,8 +136,8 @@ def nonlocalizedevent_details(context, localization=None):
                 [
                     ('Event Type', f'{sequence.nonlocalizedevent.event_type} {sequence.details["group"]}'),
                     ('Instrument', '+'.join(sequence.details['instruments'])),
-                    ('50% Area', format_area(sequence.localization.area_50)),
-                    ('90% Area', format_area(sequence.localization.area_90)),
+                    ('50% Area', format_area(localization.area_50)),
+                    ('90% Area', format_area(localization.area_90)),
                 ],
                 [
                     ('1/FAR', format_inverse_far(sequence.details['far'])),
@@ -150,8 +152,8 @@ def nonlocalizedevent_details(context, localization=None):
             [
                 ('Event Type', sequence.nonlocalizedevent.event_type),
                 ('Instrument', sequence.details['notice_type'].split()[0]),
-                ('50% Area', format_area(sequence.localization.area_50)),
-                ('90% Area', format_area(sequence.localization.area_90)),
+                ('50% Area', format_area(localization.area_50)),
+                ('90% Area', format_area(localization.area_90)),
             ],
             [
                 ('Significance', sequence.details['data_signif'].replace(' [sigma]', 'σ')),
@@ -164,8 +166,8 @@ def nonlocalizedevent_details(context, localization=None):
             [
                 ('Event Type', 'X-ray Transient'),
                 ('Instrument', sequence.details['instrument']),
-                ('50% Area', format_area(sequence.localization.area_50)),
-                ('90% Area', format_area(sequence.localization.area_90)),
+                ('50% Area', format_area(localization.area_50)),
+                ('90% Area', format_area(localization.area_90)),
             ],
             [
                 ('Image S/N', sequence.details['image_snr']),

--- a/custom_code/templatetags/nonlocalizedevent_extras.py
+++ b/custom_code/templatetags/nonlocalizedevent_extras.py
@@ -49,17 +49,17 @@ def format_distance(localization):
 
 @register.filter
 def format_area(area):
-    unit = 'deg'
+    unit = 'deg²'
     if area < 1.:
-        area *= 60.
-        unit = 'arcmin'
+        area *= 3600.
+        unit = 'arcmin²'
     if area < 1.:
-        area *= 60.
-        unit = 'arcsec'
+        area *= 3600.
+        unit = 'arcsec²'
     if area >= 10.:
-        return f'{area:.0f} {unit}²'
+        return f'{area:.0f} {unit}'
     else:
-        return f'{area:.1f} {unit}²'
+        return f'{area:.1f} {unit}'
 
 
 @register.filter

--- a/custom_code/templatetags/skymap_extras.py
+++ b/custom_code/templatetags/skymap_extras.py
@@ -84,14 +84,20 @@ def skymap(context, localization, survey_candidates=None, survey_observations=No
     return extras
 
 
+def get_preferred_localization(nle):
+    seq = nle.sequences.last()
+    if seq is not None:
+        return seq.localization if seq.external_coincidence is None else seq.external_coincidence.localization
+
+
 @register.inclusion_tag('tom_nonlocalizedevents/partials/skymap.html', takes_context=True)
 def skymap_event_id(context, survey_candidates=None, survey_observations=None):
     event_id = context['request'].GET.get('localization_event')
     if event_id is None:
         return
     nle = NonLocalizedEvent.objects.get(event_id=event_id)
-    seq = nle.sequences.last()
-    return skymap(context, seq.localization, survey_candidates, survey_observations)
+    localization = get_preferred_localization(nle)
+    return skymap(context, localization, survey_candidates, survey_observations)
 
 
 @register.filter

--- a/custom_code/urls.py
+++ b/custom_code/urls.py
@@ -5,6 +5,7 @@ from .views import TargetGroupingCreateView, CandidateListView, TargetReportView
 from .views import ObservationCreateView, TargetNameSearchView, TargetListView
 from .views import CSSFieldListView, GWListView, GRBListView, NeutrinoListView, UnknownListView
 from .views import CSSFieldExportView, CSSFieldSubmitView, EventCandidateCreateView, ProfileUpdateView
+from tom_nonlocalizedevents.views import SupereventIdView
 
 from tom_common.api_router import SharedAPIRootRouter
 
@@ -28,6 +29,7 @@ urlpatterns = [
     path('nonlocalizedevents/grb/', GRBListView.as_view(), name='grb-list'),
     path('nonlocalizedevents/neutrino/', NeutrinoListView.as_view(), name='neutrino-list'),
     path('nonlocalizedevents/unknown/', UnknownListView.as_view(), name='unknown-list'),
+    path('nonlocalizedevents/<str:event_id>/', SupereventIdView.as_view(), name='event-detail'),  # prioritize event_id
     path('nonlocalizedevents/<int:localization_id>/cssfields/', CSSFieldListView.as_view(), name='css-fields'),
     path('nonlocalizedevents/<str:event_id>/cssfields/', CSSFieldListView.as_view(), name='css-fields-latest'),
     path('nonlocalizedevents/<int:localization_id>/cssfields/export/', CSSFieldExportView.as_view(), name='css-fields-export'),

--- a/custom_code/urls.py
+++ b/custom_code/urls.py
@@ -3,7 +3,7 @@ from django.urls import path
 from tom_targets.views import TargetGroupingView, TargetGroupingDeleteView
 from .views import TargetGroupingCreateView, CandidateListView, TargetReportView, TargetClassifyView, TargetVettingView, TargetMPCView
 from .views import ObservationCreateView, TargetNameSearchView, TargetListView
-from .views import CSSFieldListView, GWListView, GRBListView, NeutrinoListView
+from .views import CSSFieldListView, GWListView, GRBListView, NeutrinoListView, UnknownListView
 from .views import CSSFieldExportView, CSSFieldSubmitView, EventCandidateCreateView, ProfileUpdateView
 
 from tom_common.api_router import SharedAPIRootRouter
@@ -27,6 +27,7 @@ urlpatterns = [
     path('nonlocalizedevents/gw/', GWListView.as_view(), name='gw-list'),
     path('nonlocalizedevents/grb/', GRBListView.as_view(), name='grb-list'),
     path('nonlocalizedevents/neutrino/', NeutrinoListView.as_view(), name='neutrino-list'),
+    path('nonlocalizedevents/unknown/', UnknownListView.as_view(), name='unknown-list'),
     path('nonlocalizedevents/<int:localization_id>/cssfields/', CSSFieldListView.as_view(), name='css-fields'),
     path('nonlocalizedevents/<str:event_id>/cssfields/', CSSFieldListView.as_view(), name='css-fields-latest'),
     path('nonlocalizedevents/<int:localization_id>/cssfields/export/', CSSFieldExportView.as_view(), name='css-fields-export'),

--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -26,6 +26,7 @@ from .forms import NonLocalizedEventFormHelper, CandidateFormHelper
 from .forms import TNS_FILTER_CHOICES, TNS_INSTRUMENT_CHOICES, TNS_CLASSIFICATION_CHOICES
 from .hooks import target_post_save, update_or_create_target_extra
 from .tasks import target_run_mpc
+from .templatetags.skymap_extras import get_preferred_localization
 
 import json
 import requests
@@ -413,9 +414,7 @@ class CSSFieldListView(FilterView):
             return EventLocalization.objects.get(id=self.kwargs['localization_id'])
         elif 'event_id' in self.kwargs:
             nle = NonLocalizedEvent.objects.get(event_id=self.kwargs['event_id'])
-            seq = nle.sequences.last()
-            if seq is not None:
-                return seq.localization
+            return get_preferred_localization(nle)
 
     def get_nonlocalizedevent(self):
         if 'localization_id' in self.kwargs:

--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -609,6 +609,17 @@ class NeutrinoListView(NonLocalizedEventListView):
         return qs
 
 
+class UnknownListView(NonLocalizedEventListView):
+    """
+    Unadorned Django ListView subclass for NonLocalizedEvent model.
+    """
+    template_name = 'tom_nonlocalizedevents/unknown_list.html'
+
+    def get_queryset(self):
+        qs = NonLocalizedEvent.objects.filter(event_type='UNK').order_by('-created')
+        return qs
+
+
 class ProfileUpdateView(LoginRequiredMixin, UpdateView):
     model = Profile
     template_name = 'tom_common/update_user_profile.html'

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -401,29 +401,11 @@ ALERT_STREAMS = [
             'USERNAME': os.getenv('SCIMMA_AUTH_USERNAME', SCIMMA_AUTH_USERNAME),
             'PASSWORD': os.getenv('SCIMMA_AUTH_PASSWORD', SCIMMA_AUTH_PASSWORD),
             'TOPIC_HANDLERS': {
+                'gcn.notices.einstein_probe.wxt.alert': 'custom_code.alertstream_handlers.handle_einstein_probe_alert',
                 'igwn.gwalert': 'custom_code.alertstream_handlers.handle_message_and_send_alerts'
             },
         },
     },
-    {
-        'ACTIVE': True,
-        'NAME': 'tom_alertstreams.alertstreams.gcn.GCNClassicAlertStream',
-        # The keys of the OPTIONS dictionary become (lower-case) properties of the AlertStream instance.
-        'OPTIONS': {
-            # see https://github.com/nasa-gcn/gcn-kafka-python#to-use for configuration details.
-            'GCN_CLASSIC_CLIENT_ID': os.getenv('GCN_CLASSIC_CLIENT_ID', GCN_CLIENT_ID),
-            'GCN_CLASSIC_CLIENT_SECRET': os.getenv('GCN_CLASSIC_CLIENT_SECRET', GCN_CLIENT_SECRET),
-            'DOMAIN': 'gcn.nasa.gov',  # optional, defaults to 'gcn.nasa.gov'
-            'CONFIG': {  # optional
-                # 'group.id': 'tom_alertstreams - llindstrom@lco.global',
-                # 'auto.offset.reset': 'earliest',
-                # 'enable.auto.commit': False
-            },
-            'TOPIC_HANDLERS': {
-                'gcn.notices.einstein_probe.wxt.alert': 'custom_code.alertstream_handlers.handle_einstein_probe_alert',
-            },
-        },
-    }
 ]
 
 VUE_FRONTEND_DIR_TOM_NONLOCAL = os.path.join(STATIC_ROOT, 'tom_nonlocalizedevents/vue')

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -406,7 +406,7 @@ ALERT_STREAMS = [
         },
     },
     {
-        'ACTIVE': False,
+        'ACTIVE': True,
         'NAME': 'tom_alertstreams.alertstreams.gcn.GCNClassicAlertStream',
         # The keys of the OPTIONS dictionary become (lower-case) properties of the AlertStream instance.
         'OPTIONS': {
@@ -420,9 +420,7 @@ ALERT_STREAMS = [
                 # 'enable.auto.commit': False
             },
             'TOPIC_HANDLERS': {
-                'gcn.classic.text.LVC_PRELIMINARY': 'tom_nonlocalizedevents.alertstream_handlers.gcn_event_handler.handle_message',
-                'gcn.classic.text.LVC_INITIAL': 'tom_nonlocalizedevents.alertstream_handlers.gcn_event_handler.handle_message',
-                'gcn.classic.text.LVC_RETRACTION': 'tom_nonlocalizedevents.alertstream_handlers.gcn_event_handler.handle_retraction',
+                'gcn.notices.einstein_probe.wxt.alert': 'custom_code.alertstream_handlers.handle_einstein_probe_alert',
             },
         },
     }

--- a/saguaro_tom/settings_local.template.py
+++ b/saguaro_tom/settings_local.template.py
@@ -35,6 +35,7 @@ TARGET_LINKS = [  # links to TOMs for target pages, {target.name} is replaced by
     ('https://tom0.edu/targets/{target.id}/', 'Name of TOM 0'),  # TOM corresponding to Slack workspace 0
     ('https://tom1.edu/targets/{target.name}/', 'Name of TOM 1'),  # TOM corresponding to Slack workspace 1
 ]
+SLACK_EP_URL = 'https://hooks.slack.com/services/.../.../...'  # incoming webhook for Einstein Probe alerts
 SLACK_TNS_URL = 'https://hooks.slack.com/services/.../.../...'  # incoming webhook for TNS transient alerts
 SLACK_URLS = [  # list of lists of Slack URLs for incoming webhooks
     [  # list of URLs for Slack workspace 0

--- a/templates/tom_common/navbar_content.html
+++ b/templates/tom_common/navbar_content.html
@@ -19,6 +19,9 @@ For customization instructions, see tom_common/base.html
         <li class="nav-item">
             <a class="nav-link" href="{% url 'custom_code:neutrino-list' %}" style="color:black">Neutrinos</a>
         </li>
+        <li class="nav-item">
+            <a class="nav-link" href="{% url 'custom_code:unknown-list' %}" style="color:black">X-ray Transients</a>
+        </li>
     </ul>
 </li>
 <li class="nav-item {% if 'targets' in request.resolver_match.route %}active{% endif %}">

--- a/templates/tom_nonlocalizedevents/grb_list.html
+++ b/templates/tom_nonlocalizedevents/grb_list.html
@@ -31,7 +31,7 @@
       {% else %}
       <tr>
       {% endif %}
-        <td><a href="{% url 'nonlocalizedevents:detail'  event.id %}" target="_blank">{{ event.event_id }}</a></td>
+        <td><a href="{% url 'nonlocalizedevents:event-detail'  event.event_id %}" target="_blank">{{ event.event_id }}</a></td>
         <td title="Survey Plans">
         {% for localization in event.localizations|sort_localizations %}
             {% if localization.external_coincidences.exists %}

--- a/templates/tom_nonlocalizedevents/neutrino_list.html
+++ b/templates/tom_nonlocalizedevents/neutrino_list.html
@@ -31,7 +31,7 @@
       {% else %}
       <tr>
       {% endif %}
-        <td><a href="{% url 'nonlocalizedevents:detail'  event.id %}" target="_blank">{{ event.event_id }}</a></td>
+        <td><a href="{% url 'nonlocalizedevents:event-detail'  event.event_id %}" target="_blank">{{ event.event_id }}</a></td>
         <td title="Survey Plans">
         {% for localization in event.localizations|sort_localizations %}
             {% if localization.external_coincidences.exists %}

--- a/templates/tom_nonlocalizedevents/partials/nonlocalizedevent_details.html
+++ b/templates/tom_nonlocalizedevents/partials/nonlocalizedevent_details.html
@@ -1,57 +1,13 @@
 {% load nonlocalizedevent_extras %}
 <div class="row">
+{% for column in details %}
     <div class="col-md-4">
         <dl class="row">
-            <dt class="col-sm-4">1/FAR</dt>
-            <dd class="col-sm-8">{{ sequence.details.far|format_inverse_far }}</dd>
-            {% if sequence.details.group == 'CBC' %}
-                <dt class="col-sm-4">Distance</dt>
-                <dd class="col-sm-8">{{ sequence.localization|format_distance }}</dd>
-            {% endif %}
-            <dt class="col-sm-4">50% Area</dt>
-            <dd class="col-sm-8">{{ sequence.localization.area_50|floatformat:0 }} deg²</dd>
-            <dt class="col-sm-4">90% Area</dt>
-            <dd class="col-sm-8">{{ sequence.localization.area_90|floatformat:0 }} deg²</dd>
+        {% for key, value in column %}
+            <dt class="col-sm-4">{{ key }}</dt>
+            <dd class="col-sm-8">{{ value }}</dd>
+        {% endfor %}
         </dl>
     </div>
-{% if sequence.details.group == 'CBC' %}
-    <div class="col-md-4">
-        <dl class="row">
-            {% for property, prob in sequence.details.properties.items %}
-                <dt class="col-sm-4">{{ property }}</dt>
-                <dd class="col-sm-8">{{ prob|percentformat }}</dd>
-            {% endfor %}
-        </dl>
-    </div>
-    <div class="col-md-4">
-        <dl class="row">
-            {% for class, prob in sequence.details.classification.items %}
-                <dt class="col-sm-4">{{ class }}</dt>
-                <dd class="col-sm-8">{{ prob|percentformat }}</dd>
-            {% endfor %}
-        </dl>
-    </div>
-{% elif sequence.details.group == 'Burst' %}
-    <div class="col-md-4">
-        <dl class="row">
-            <dt class="col-sm-4">Group</dt>
-            <dd class="col-sm-8">{{ sequence.details.group }}</dd>
-            <dt class="col-sm-4">Duration</dt>
-            <dd class="col-sm-8">{{ sequence.details.duration|millisecondformat }}</dd>
-            <dt class="col-sm-4">Frequency</dt>
-            <dd class="col-sm-8">{{ sequence.details.central_frequency|floatformat }} Hz</dd>
-        </dl>
-    </div>
-{% else %}
-        <div class="col-md-4">
-        <dl class="row">
-            <dt class="col-sm-4">Energy</dt>
-            <dd class="col-sm-8">{{ sequence.details.image_energy_range }} keV</dd>
-            <dt class="col-sm-4">Count Rate</dt>
-            <dd class="col-sm-8">{{ sequence.details.net_count_rate|floatformat }} s<sup>-1</sup></dd>
-            <dt class="col-sm-4">Image S/N</dt>
-            <dd class="col-sm-8">{{ sequence.details.image_snr|floatformat }}</dd>
-        </dl>
-    </div>
-{% endif %}
+{% endfor %}
 </div>

--- a/templates/tom_nonlocalizedevents/partials/nonlocalizedevent_details.html
+++ b/templates/tom_nonlocalizedevents/partials/nonlocalizedevent_details.html
@@ -45,12 +45,12 @@
 {% else %}
         <div class="col-md-4">
         <dl class="row">
-            <dt class="col-sm-4">Image Energy Range</dt>
-            <dd class="col-sm-8">{{ sequence.details.image_energy_range }}</dd>
-            <dt class="col-sm-4">Net Count Rate</dt>
-            <dd class="col-sm-8">{{ sequence.details.net_count_rate|floatformat }}</dd>
+            <dt class="col-sm-4">Energy</dt>
+            <dd class="col-sm-8">{{ sequence.details.image_energy_range }} keV</dd>
+            <dt class="col-sm-4">Count Rate</dt>
+            <dd class="col-sm-8">{{ sequence.details.net_count_rate|floatformat }} s<sup>-1</sup></dd>
             <dt class="col-sm-4">Image S/N</dt>
-            <dd class="col-sm-8">{{ sequence.details.image_snr|floatformat }} Hz</dd>
+            <dd class="col-sm-8">{{ sequence.details.image_snr|floatformat }}</dd>
         </dl>
     </div>
 {% endif %}

--- a/templates/tom_nonlocalizedevents/partials/nonlocalizedevent_details.html
+++ b/templates/tom_nonlocalizedevents/partials/nonlocalizedevent_details.html
@@ -31,7 +31,7 @@
             {% endfor %}
         </dl>
     </div>
-{% else %}
+{% elif sequence.details.group == 'Burst' %}
     <div class="col-md-4">
         <dl class="row">
             <dt class="col-sm-4">Group</dt>
@@ -40,6 +40,17 @@
             <dd class="col-sm-8">{{ sequence.details.duration|millisecondformat }}</dd>
             <dt class="col-sm-4">Frequency</dt>
             <dd class="col-sm-8">{{ sequence.details.central_frequency|floatformat }} Hz</dd>
+        </dl>
+    </div>
+{% else %}
+        <div class="col-md-4">
+        <dl class="row">
+            <dt class="col-sm-4">Image Energy Range</dt>
+            <dd class="col-sm-8">{{ sequence.details.image_energy_range }}</dd>
+            <dt class="col-sm-4">Net Count Rate</dt>
+            <dd class="col-sm-8">{{ sequence.details.net_count_rate|floatformat }}</dd>
+            <dt class="col-sm-4">Image S/N</dt>
+            <dd class="col-sm-8">{{ sequence.details.image_snr|floatformat }} Hz</dd>
         </dl>
     </div>
 {% endif %}

--- a/templates/tom_nonlocalizedevents/unknown_list.html
+++ b/templates/tom_nonlocalizedevents/unknown_list.html
@@ -1,0 +1,73 @@
+{% extends 'tom_common/index.html' %}
+{% load bootstrap4 crispy_forms_tags nonlocalizedevent_extras %}
+{% block title %}X-ray Transients{% endblock %}
+{% block content %}
+<h1>X-ray Transients</h1>
+<div class="row">
+    <div class="col-md-12">
+    <form action="" method="get" class="form">
+      {% crispy filter.form %}
+    </form>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+    {% bootstrap_pagination page_obj extra=request.GET.urlencode %}
+    {% if object_list %}
+    <table class="table">
+      <thead>
+      <tr>
+        <th scope="col">Detail Page</th>
+        <th scope="col" title="Survey Plans">Plans</th>
+        <th scope="col" title="Survey Observations">Obs.</th>
+        <th scope="col" title="Survey Candidates">Cand.</th>
+        <th scope="col" title="Hermes">Hermes</th>
+      </tr>
+      </thead>
+      <tbody>
+      {% for event in object_list %}
+      {% if event.sequences.last.details.significant %}
+      <tr style="font-weight: bold">
+      {% else %}
+      <tr>
+      {% endif %}
+        <td><a href="{% url 'nonlocalizedevents:detail'  event.id %}" target="_blank">{{ event.event_id }}</a></td>
+        <td title="Survey Plans">
+        {% for localization in event.localizations|sort_localizations %}
+            {% if localization.external_coincidences.exists %}
+                <a href="{% url 'custom_code:css-fields' localization.id %}?grouping_ngroups=3&grouping_nfields=12"
+                   title="{{ localization.external_coincidences.last.sequences.last.event_subtype }} Combined"
+                   target="_blank">
+                {{ localization.external_coincidences.last.sequences.last.sequence_id }}c
+            {% else %}
+                <a href="{% url 'custom_code:css-fields' localization.id %}?grouping_ngroups=3&grouping_nfields=12"
+                   title="{{ localization.sequences.last.event_subtype }}"
+                   target="_blank">
+                {{ localization.sequences.last.sequence_id }}
+            {% endif %}
+            </a>
+        {% endfor %}
+        </td>
+        <td title="Survey Observations">
+            <a href="{% url 'surveys:observations' %}?localization_event={{ event.event_id }}&localization_prob=95&localization_dt=3" target="_blank">Obs.</a>
+        </td>
+        <td title="Survey Candidates">
+            <a href="{% url 'custom_code:candidates' %}?localization_event={{ event.event_id }}&localization_prob=95&localization_dt=3&classification=0&order=-mlscore_real" target="_blank">Cand.</a>
+        </td>
+        <td title="Hermes">
+          <a href="{{ event.hermes_url }}" target="_blank">Hermes</a>
+        </td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    {% bootstrap_pagination page_obj extra=request.GET.urlencode %}
+    {% else %}
+    <p>No events have been created. Create Superevents via the admin interface, the REST API,
+        or the readstreams management command.</p>
+    <p>Coming soon: event creation from the <a href="{% url 'tom_alerts:list' %}">HERMES Alert Broker</a>.</p>
+    {% endif %}
+    </div>
+</div>
+
+{% endblock content %}

--- a/templates/tom_nonlocalizedevents/unknown_list.html
+++ b/templates/tom_nonlocalizedevents/unknown_list.html
@@ -31,7 +31,7 @@
       {% else %}
       <tr>
       {% endif %}
-        <td><a href="{% url 'nonlocalizedevents:detail'  event.id %}" target="_blank">{{ event.event_id }}</a></td>
+        <td><a href="{% url 'nonlocalizedevents:event-detail'  event.event_id %}" target="_blank">{{ event.event_id }}</a></td>
         <td title="Survey Plans">
         {% for localization in event.localizations|sort_localizations %}
             {% if localization.external_coincidences.exists %}


### PR DESCRIPTION
This adds support for Einstein Probe x-ray events to the TOM. To do this we had to write an alert handler function, write a function to create a healpix localization from coordinates and a radius, and generalize the nonlocalized event pages. X-ray transients are currently being stored as nonlocalized event type UNKNOWN for lack of a better category.

I also found some small issues with the way we were handling external coincidence skymaps while working on this PR. These fixes would have required a complicated merge, so I just committed them here (bad practice, I know).