### PR TITLE
create survey plan on alert, not on page load

### DIFF
--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -9,7 +9,7 @@ import logging
 import json
 from .templatetags.nonlocalizedevent_extras import format_inverse_far, format_distance, format_area, get_most_likely_class
 from .healpix_utils import update_all_credible_region_percents_for_survey_fields, create_elliptical_localization
-from .cssfield_selection import calculate_footprint_probabilities
+from .cssfield_selection import calculate_footprint_probabilities, rank_css_fields
 from .models import CredibleRegionContour
 from astropy.table import Table
 from io import BytesIO
@@ -247,6 +247,7 @@ def handle_message_and_send_alerts(message, metadata):
                 skymap = Table.read(BytesIO(skymap_bytes))
                 calculate_credible_region(skymap, localization)
                 calculate_footprint_probabilities(skymap, localization)
+                rank_css_fields(localization.surveyfieldcredibleregions)
 
     logger.info(f'Finished processing alert for {nle.event_id}')
 
@@ -301,6 +302,7 @@ def handle_einstein_probe_alert(message, metadata):
             skymap['PROBDENSITY'].unit = '1 / sr'
             calculate_credible_region(skymap, localization)
             calculate_footprint_probabilities(skymap, localization)
+            rank_css_fields(localization.surveyfieldcredibleregions)
 
     slack_alert = f'Received Einstein Probe trigger <{settings.NLE_LINKS[0][0]}|{{nle.event_id}}>'
     json_data = json.dumps({'text': slack_alert.format(nle=nonlocalizedevent)}).encode('ascii')

--- a/custom_code/cssfield_selection.py
+++ b/custom_code/cssfield_selection.py
@@ -170,3 +170,4 @@ def rank_css_fields(queryset, n_select=12, n_groups=3, now=None):
             else:
                 logger.warning('No adjacent fields to select')
                 break
+    logger.info(f'Created new survey plan with {n_groups:d} groups of {n_select:d} fields')

--- a/custom_code/filters.py
+++ b/custom_code/filters.py
@@ -164,9 +164,7 @@ class CSSFieldFilter(django_filters.Filter):
     def filter(self, queryset, value):
         if value:
             rank_css_fields(queryset, n_groups=value[0], n_select=value[1], now=value[2])
-            return queryset.filter(group__isnull=False, rank_in_group__isnull=False).order_by('group', 'rank_in_group')
-        else:
-            return queryset.order_by('group', 'rank_in_group')
+        return queryset
 
 
 class CSSFieldCredibleRegionFilter(django_filters.FilterSet):

--- a/custom_code/models.py
+++ b/custom_code/models.py
@@ -150,7 +150,7 @@ class SurveyFieldCredibleRegion(models.Model):
         constraints = [
             models.UniqueConstraint(fields=['localization', 'survey_field'], name='unique_localization_survey_field')
         ]
-        ordering = ['-probability_contained']
+        ordering = ['group', 'rank_in_group', '-probability_contained']
 
 
 class CredibleRegionContour(models.Model):

--- a/templates/tom_nonlocalizedevents/cssfield_list.html
+++ b/templates/tom_nonlocalizedevents/cssfield_list.html
@@ -43,13 +43,13 @@
       <tbody>
         {% for link in object_list %}
         <tr>
-          <td><input type="checkbox" name="selected-target" value="{{ link.id }}" onClick="single_select()" checked /></td>
+          <td><input type="checkbox" name="selected-target" value="{{ link.id }}" onClick="single_select()" {% if link.group and link.rank_in_group  %}checked{% endif %} /></td>
           <td>{{ link.survey_field.name }}</td>
           <td>{{ link.survey_field.ra | floatformat:"6" }}</td>
           <td>{{ link.survey_field.dec | floatformat:"6" }}</td>
           <td>{{ link.survey_field.has_reference }}</td>
           <td>{{ link.probability_contained | floatformat:"6" }}</td>
-          <td>{{ link.group }}:{{ link.rank_in_group }}</td>
+          <td>{% if link.group and link.rank_in_group %}{{ link.group }}:{{ link.rank_in_group }}{% endif %}</td>
           <td>{{ link.observation_record.created|date:"M d H:i" }}</td>
           <td>{{ link.scheduled_start | date:"M d H:i" }}</td>
         </tr>

--- a/templates/tom_nonlocalizedevents/grb_list.html
+++ b/templates/tom_nonlocalizedevents/grb_list.html
@@ -35,12 +35,12 @@
         <td title="Survey Plans">
         {% for localization in event.localizations|sort_localizations %}
             {% if localization.external_coincidences.exists %}
-                <a href="{% url 'custom_code:css-fields' localization.id %}?grouping_ngroups=3&grouping_nfields=12"
+                <a href="{% url 'custom_code:css-fields' localization.id %}"
                    title="{{ localization.external_coincidences.last.sequences.last.event_subtype }} Combined"
                    target="_blank">
                 {{ localization.external_coincidences.last.sequences.last.sequence_id }}c
             {% else %}
-                <a href="{% url 'custom_code:css-fields' localization.id %}?grouping_ngroups=3&grouping_nfields=12"
+                <a href="{% url 'custom_code:css-fields' localization.id %}"
                    title="{{ localization.sequences.last.event_subtype }}"
                    target="_blank">
                 {{ localization.sequences.last.sequence_id }}

--- a/templates/tom_nonlocalizedevents/gw_list.html
+++ b/templates/tom_nonlocalizedevents/gw_list.html
@@ -52,12 +52,12 @@
         <td title="Survey Plans">
         {% for localization in event.localizations|sort_localizations %}
             {% if localization.external_coincidences.exists %}
-                <a href="{% url 'custom_code:css-fields' localization.id %}?grouping_ngroups=3&grouping_nfields=12"
+                <a href="{% url 'custom_code:css-fields' localization.id %}"
                    title="{{ localization.external_coincidences.last.sequences.last.event_subtype }} Combined"
                    target="_blank">
                 {{ localization.external_coincidences.last.sequences.last.sequence_id }}c
             {% else %}
-                <a href="{% url 'custom_code:css-fields' localization.id %}?grouping_ngroups=3&grouping_nfields=12"
+                <a href="{% url 'custom_code:css-fields' localization.id %}"
                    title="{{ localization.sequences.last.event_subtype }}"
                    target="_blank">
                 {{ localization.sequences.last.sequence_id }}

--- a/templates/tom_nonlocalizedevents/neutrino_list.html
+++ b/templates/tom_nonlocalizedevents/neutrino_list.html
@@ -35,12 +35,12 @@
         <td title="Survey Plans">
         {% for localization in event.localizations|sort_localizations %}
             {% if localization.external_coincidences.exists %}
-                <a href="{% url 'custom_code:css-fields' localization.id %}?grouping_ngroups=3&grouping_nfields=12"
+                <a href="{% url 'custom_code:css-fields' localization.id %}"
                    title="{{ localization.external_coincidences.last.sequences.last.event_subtype }} Combined"
                    target="_blank">
                 {{ localization.external_coincidences.last.sequences.last.sequence_id }}c
             {% else %}
-                <a href="{% url 'custom_code:css-fields' localization.id %}?grouping_ngroups=3&grouping_nfields=12"
+                <a href="{% url 'custom_code:css-fields' localization.id %}"
                    title="{{ localization.sequences.last.event_subtype }}"
                    target="_blank">
                 {{ localization.sequences.last.sequence_id }}

--- a/templates/tom_nonlocalizedevents/unknown_list.html
+++ b/templates/tom_nonlocalizedevents/unknown_list.html
@@ -35,12 +35,12 @@
         <td title="Survey Plans">
         {% for localization in event.localizations|sort_localizations %}
             {% if localization.external_coincidences.exists %}
-                <a href="{% url 'custom_code:css-fields' localization.id %}?grouping_ngroups=3&grouping_nfields=12"
+                <a href="{% url 'custom_code:css-fields' localization.id %}"
                    title="{{ localization.external_coincidences.last.sequences.last.event_subtype }} Combined"
                    target="_blank">
                 {{ localization.external_coincidences.last.sequences.last.sequence_id }}c
             {% else %}
-                <a href="{% url 'custom_code:css-fields' localization.id %}?grouping_ngroups=3&grouping_nfields=12"
+                <a href="{% url 'custom_code:css-fields' localization.id %}"
                    title="{{ localization.sequences.last.event_subtype }}"
                    target="_blank">
                 {{ localization.sequences.last.sequence_id }}


### PR DESCRIPTION
At least partially resolves #120 by (1) creating an initial survey plan for each alert ingested and (2) not regenerating the plan each time the plan page loads. However you can still regenerate the plan by filling out the fields at the right of the page and clicking the Filter button.

Another small change here is that _all_ survey fields are shown in the list by default, but those not included in the plan are listed at the end, ranked by decreasing probability, and unchecked by default.

This does _not_ address point (3) of #120, to automatically create multiple observing plans. If we do that, we may also want to change the field selection algorithm to reoptimize the groups based on how many sets we are going to submit. I suggest we make this a separate issue if needed.