### PR TITLE
use new public permission from tomtoolkit 2.24.0 without migrations

### DIFF
--- a/custom_code/management/commands/ingest_tns.py
+++ b/custom_code/management/commands/ingest_tns.py
@@ -187,8 +187,8 @@ class Command(BaseCommand):
         new_targets = Target.objects.raw(
             """
             --STEP 4: add all other unmatched TNS transients to the targets table (removing duplicate names)
-            INSERT INTO tom_targets_basetarget (name, type, created, modified, ra, dec, epoch, scheme)
-            SELECT CONCAT(name_prefix, name), 'SIDEREAL', NOW(), NOW(), ra, declination, 2000, ''
+            INSERT INTO tom_targets_basetarget (name, type, created, modified, permissions, ra, dec, epoch, scheme)
+            SELECT CONCAT(name_prefix, name), 'SIDEREAL', NOW(), NOW(), 'PUBLIC', ra, declination, 2000, ''
             FROM tns_q3c WHERE name_prefix != 'FRB' AND name != '2023hzc' -- this is a duplicate of AT2016jlf in the TNS
             ON CONFLICT (name) DO NOTHING
             RETURNING *;

--- a/custom_code/templatetags/target_list_extras.py
+++ b/custom_code/templatetags/target_list_extras.py
@@ -1,13 +1,12 @@
 from django import template
 from ..models import Candidate, TargetListExtra
-from tom_targets.models import TargetExtra
-from guardian.shortcuts import get_objects_for_user
+from tom_targets.models import Target, TargetExtra
+from tom_targets.permissions import targets_for_user
 from tom_surveys.models import SurveyField, SurveyObservationRecord
 from .skymap_extras import CSS_FOOTPRINT, centers_to_vertices
 import numpy as np
 from matplotlib.path import Path
 import json
-import numpy as np
 
 register = template.Library()
 
@@ -79,6 +78,6 @@ def recent_confirmed_targets(context, limit=10):
     Displays a list of the most recently created targets in the TOM up to the given limit, or 10 if not specified.
     """
     user = context['request'].user
-    targets_for_user = get_objects_for_user(user, 'tom_targets.view_target')
-    confirmed_targets_for_user = targets_for_user.exclude(name__startswith='J')
+    all_targets_for_user = targets_for_user(user, Target.objects.all(), 'view_target')
+    confirmed_targets_for_user = all_targets_for_user.exclude(name__startswith='J')
     return {'targets': confirmed_targets_for_user.order_by('-created')[:limit]}

--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -11,9 +11,9 @@ from django.views.generic.edit import CreateView, TemplateResponseMixin, FormMix
 from django_filters.views import FilterView
 from django.shortcuts import redirect
 from guardian.mixins import PermissionListMixin
-from guardian.shortcuts import get_objects_for_user
 
 from tom_targets.models import Target, TargetList
+from tom_targets.permissions import targets_for_user
 from tom_dataproducts.models import ReducedDatum
 from tom_targets.views import TargetNameSearchView as OldTargetNameSearchView, TargetListView as OldTargetListView
 from tom_observations.views import ObservationCreateView as OldObservationCreateView
@@ -117,7 +117,7 @@ class CandidateListView(FilterView):
         :rtype: QuerySet
         """
         return super().get_queryset().filter(
-            target__in=get_objects_for_user(self.request.user, 'tom_targets.view_target')
+            target__in=targets_for_user(self.request.user, Target.objects.all(), 'view_target')
         ).annotate(detections=Count('target__candidate'))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ lightcurve-fitting
 ligo.skymap
 matplotlib
 numpy
-tomtoolkit==2.22.1
+tomtoolkit==2.24.0
 tom-alertstreams
 tom-mmt @ git+https://github.com/griffin-h/tom_mmt
 tom-nonlocalizedevents==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ lightcurve-fitting
 ligo.skymap
 matplotlib
 numpy
-tomtoolkit==2.24.4
+tomtoolkit==2.24.0
 tom-alertstreams
 tom-mmt @ git+https://github.com/griffin-h/tom_mmt
 tom-nonlocalizedevents==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ lightcurve-fitting
 ligo.skymap
 matplotlib
 numpy
-tomtoolkit==2.24.0
+tomtoolkit==2.24.4
 tom-alertstreams
 tom-mmt @ git+https://github.com/griffin-h/tom_mmt
 tom-nonlocalizedevents==0.8.1


### PR DESCRIPTION
This is identical to #125 but without the migrations in `custom_code`, which were preventing the migrations from `tom_base` from being applied (see https://github.com/TOMToolkit/tom_base/issues/1220). Instead, I migrated to tom_targets 0024, faked tom_targets 0025 using:
```
update tom_targets_basetarget set permissions='PUBLIC';
delete from guardian_groupobjectpermission where content_type=14 and group_id=1;
delete from guardian_userobjectpermission where content_type=14 and group_id=1;
delete from auth_user_groups where group_id=1;
delete from auth_group where id=1;
update auth_user set is_superuser=false where id > 2;
insert into django_migrations (app, name, applied) values ('tom_targets', '0025_auto_20250206_2017', NOW());
```
and then applied tom_targets 0026.