### PR TITLE
Switch from dramatiq to django-tasks to be compatible with tom_base v2.24.2

### DIFF
--- a/custom_code/management/commands/ingest_tns.py
+++ b/custom_code/management/commands/ingest_tns.py
@@ -35,7 +35,7 @@ def vet_or_post_error(target):
         if detections.exists():
             target_run_mpc.enqueue(detections.latest().id)
         mjd_now = Time.now().mjd
-        atlas_query.enqueue(mjd_now - 20., mjd_now, target.id, 'atlas_photometry')
+        atlas_query.enqueue(mjd_now - 20., mjd_now, target.id, 'atlas_photometry', queue_name="atlas")
                          
     except Exception as e:
         slack_alert = f'Error vetting TNS target {target.name}:\n{e}'

--- a/custom_code/management/commands/ingest_tns.py
+++ b/custom_code/management/commands/ingest_tns.py
@@ -33,9 +33,9 @@ def vet_or_post_error(target):
             requests.post(settings.SLACK_TNS_URL, data=json_data, headers={'Content-Type': 'application/json'})
         detections = target.reduceddatum_set.filter(data_type="photometry", value__magnitude__isnull=False)
         if detections.exists():
-            target_run_mpc.send(detections.latest().id)
+            target_run_mpc.enqueue(detections.latest().id)
         mjd_now = Time.now().mjd
-        atlas_query.send(mjd_now - 20., mjd_now, target.id, 'atlas_photometry')
+        atlas_query.enqueue(mjd_now - 20., mjd_now, target.id, 'atlas_photometry')
                          
     except Exception as e:
         slack_alert = f'Error vetting TNS target {target.name}:\n{e}'

--- a/custom_code/tasks.py
+++ b/custom_code/tasks.py
@@ -9,7 +9,7 @@ from .hooks import update_or_create_target_extra
 logger = logging.getLogger(__name__)
 
 
-@task
+@task(queue_name="mpc")
 def target_run_mpc(latest_det_id, _verbose=False):
     """check if a given photometric detection is a minor planet"""
     latest_det = ReducedDatum.objects.get(id=latest_det_id)

--- a/custom_code/tasks.py
+++ b/custom_code/tasks.py
@@ -2,14 +2,14 @@ import logging
 from kne_cand_vetting.mpc import minor_planet_match
 from tom_dataproducts.models import ReducedDatum
 from astropy.time import Time
-import dramatiq
+from django_tasks import task
 
 from .hooks import update_or_create_target_extra
 
 logger = logging.getLogger(__name__)
 
 
-@dramatiq.actor
+@task
 def target_run_mpc(latest_det_id, _verbose=False):
     """check if a given photometric detection is a minor planet"""
     latest_det = ReducedDatum.objects.get(id=latest_det_id)

--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -359,8 +359,7 @@ class TargetMPCView(LoginRequiredMixin, RedirectView):
                                            value__magnitude__isnull=False)
         if phot.exists():
             messages.info(request, "Running minor planet checker. Refresh after ~1 minute to see matches.")
-            dramatiq_msg = target_run_mpc.send(phot.latest().id)  # check the latest detection
-            logger.info(dramatiq_msg)
+            target_run_mpc.enqueue(phot.latest().id)  # check the latest detection
         else:
             messages.error(request, "Must have at least one photometric detection to run minor planet checker.")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-dramatiq
 django-extensions
 django-filter
 django-guardian
-dramatiq[watch, redis]
+django-tasks
 healpix-alchemy
 healpy
 kne-cand-vetting @ git+https://github.com/SAGUARO-MMA/kne-cand-vetting
@@ -15,7 +15,7 @@ lightcurve-fitting
 ligo.skymap
 matplotlib
 numpy
-tomtoolkit==2.24.0
+tomtoolkit==2.24.2
 tom-alertstreams
 tom-mmt @ git+https://github.com/griffin-h/tom_mmt
 tom-nonlocalizedevents==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ astropy
 astroquery
 django
 django-crispy-forms
-django-dramatiq
 django-extensions
 django-filter
 django-guardian

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -106,7 +106,8 @@ WSGI_APPLICATION = 'saguaro_tom.wsgi.application'
 
 TASKS = {
     "default": {
-        "BACKEND": "django_tasks.backends.database.DatabaseBackend"
+        "BACKEND": "django_tasks.backends.database.DatabaseBackend",
+        "QUEUES": ["default", "mpc", "atlas"]
     }
 }
 

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -61,7 +61,8 @@ INSTALLED_APPS = [
     'custom_code',
     'tom_surveys',
     'tom_treasuremap',
-    'django_dramatiq',
+    'django_tasks',
+    'django_tasks.backends.database',
 ]
 
 SITE_ID = 1
@@ -103,18 +104,10 @@ CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
 WSGI_APPLICATION = 'saguaro_tom.wsgi.application'
 
-DRAMATIQ_BROKER = {
-    "BROKER": "dramatiq.brokers.redis.RedisBroker",
-    "OPTIONS": {
-        "url": "redis://localhost:6379"
-    },
-    "MIDDLEWARE": [
-        "dramatiq.middleware.AgeLimit",
-        "dramatiq.middleware.TimeLimit",
-        "dramatiq.middleware.Callbacks",
-        "dramatiq.middleware.Retries",
-        "django_dramatiq.middleware.DbConnectionsMiddleware",
-    ]
+TASKS = {
+    "default": {
+        "BACKEND": "django_tasks.backends.database.DatabaseBackend"
+    }
 }
 
 # Database


### PR DESCRIPTION
The TOM Toolkit switched from `dramatiq` to `django-tasks` for asynchronous tasks in v2.24.2 (see https://github.com/TOMToolkit/tom_base/pull/1199). This updates our vetting software to match.