### PR TITLE
Fix TNS links for FRBs

### DIFF
--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -99,7 +99,8 @@ def target_post_save(target, created, tns_time_limit: float=5.):
                     break
 
             # now query the real TNS by name for even more recent updates
-            get_obj = [("objname", basename), ("objid", ""), ("photometry", "1"), ("spectra", "0")]
+            objname = iau_name if iau_name.startswith('FRB') else basename
+            get_obj = [("objname", objname), ("objid", ""), ("photometry", "1"), ("spectra", "0")]
             response, time_to_wait = TNS_get(get_obj,
                                              settings.BROKERS['TNS']['bot_id'],
                                              settings.BROKERS['TNS']['bot_name'],

--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -126,7 +126,7 @@ def target_post_save(target, created, tns_time_limit: float=5.):
                     value = {'filter': candidate['filters']['name']}
                     if candidate['flux']:  # detection
                         value['magnitude'] = float(candidate['flux'])
-                    else:
+                    elif candidate['limflux']:
                         value['limit'] = float(candidate['limflux'])
                     if candidate['fluxerr']:  # not empty or zero
                         value['error'] = float(candidate['fluxerr'])

--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -126,8 +126,10 @@ def target_post_save(target, created, tns_time_limit: float=5.):
                     value = {'filter': candidate['filters']['name']}
                     if candidate['flux']:  # detection
                         value['magnitude'] = float(candidate['flux'])
-                    elif candidate['limflux']:
+                    elif candidate['limflux']:  # nondetection
                         value['limit'] = float(candidate['limflux'])
+                    else:  # something else, maybe an FRB; don't ingest it
+                        continue
                     if candidate['fluxerr']:  # not empty or zero
                         value['error'] = float(candidate['fluxerr'])
                     rd, created = ReducedDatum.objects.get_or_create(

--- a/custom_code/management/commands/ingest_tns.py
+++ b/custom_code/management/commands/ingest_tns.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
                         tns.ra,
                         tns.declination as dec
                     FROM tns_q3c AS tns
-                    WHERE q3c_join(target.ra, target.dec, tns.ra, tns.declination, 2. / 3600) AND name_prefix != 'FRB'
+                    WHERE q3c_join(target.ra, target.dec, tns.ra, tns.declination, 2. / 3600)
                     ORDER BY sep, discoverydate LIMIT 1 -- if there are duplicates in the TNS, use the earlier one
                 ) AS t ON true
                 WHERE t.tns_name IS NOT NULL;
@@ -167,7 +167,7 @@ class Command(BaseCommand):
             --STEP 4: add all other unmatched TNS transients to the targets table (removing duplicate names)
             INSERT INTO tom_targets_basetarget (name, type, created, modified, permissions, ra, dec, epoch, scheme)
             SELECT CONCAT(name_prefix, name), 'SIDEREAL', NOW(), NOW(), 'PUBLIC', ra, declination, 2000, ''
-            FROM tns_q3c WHERE name_prefix != 'FRB' AND name != '2023hzc' -- this is a duplicate of AT2016jlf in the TNS
+            FROM tns_q3c WHERE name != '2023hzc' -- this is a duplicate of AT2016jlf in the TNS
             ON CONFLICT (name) DO NOTHING
             RETURNING *;
             """

--- a/custom_code/management/commands/ingest_tns.py
+++ b/custom_code/management/commands/ingest_tns.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
                         tns.ra,
                         tns.declination as dec
                     FROM tns_q3c AS tns
-                    WHERE q3c_join(target.ra, target.dec, tns.ra, tns.declination, 2. / 3600)
+                    WHERE q3c_join(target.ra, target.dec, tns.ra, tns.declination, 2. / 3600) AND name_prefix != 'FRB'
                     ORDER BY sep, discoverydate LIMIT 1 -- if there are duplicates in the TNS, use the earlier one
                 ) AS t ON true
                 WHERE t.tns_name IS NOT NULL;
@@ -167,7 +167,7 @@ class Command(BaseCommand):
             --STEP 4: add all other unmatched TNS transients to the targets table (removing duplicate names)
             INSERT INTO tom_targets_basetarget (name, type, created, modified, permissions, ra, dec, epoch, scheme)
             SELECT CONCAT(name_prefix, name), 'SIDEREAL', NOW(), NOW(), 'PUBLIC', ra, declination, 2000, ''
-            FROM tns_q3c WHERE name != '2023hzc' -- this is a duplicate of AT2016jlf in the TNS
+            FROM tns_q3c WHERE name_prefix != 'FRB' AND name != '2023hzc' -- this is a duplicate of AT2016jlf in the TNS
             ON CONFLICT (name) DO NOTHING
             RETURNING *;
             """

--- a/custom_code/templatetags/target_extras.py
+++ b/custom_code/templatetags/target_extras.py
@@ -27,7 +27,12 @@ def split_name(name):
     """Splits the name into a prefix, consisting of no digits, and a basename, which starts with its first digit"""
     res = re.match('(?P<prefix>\D*)(?P<basename>.*)', name)
     name = res.groupdict()
-    name['has_tns_prefix'] = name['prefix'] in TNS_PREFIXES
+    if name['prefix'] == 'FRB':
+        name['tns_objname'] = name
+    elif name['prefix'] in TNS_PREFIXES:
+        name['tns_objname'] = name['basename']
+    else:
+        name['tns_objname'] = None
     return name
 
 

--- a/custom_code/templatetags/target_extras.py
+++ b/custom_code/templatetags/target_extras.py
@@ -6,7 +6,7 @@ import re
 
 register = template.Library()
 
-TNS_PREFIXES = ["AT", "SN", "TDE"]
+TNS_PREFIXES = ["AT", "SN", "TDE", "FRB"]
 
 
 @register.filter

--- a/custom_code/templatetags/target_extras.py
+++ b/custom_code/templatetags/target_extras.py
@@ -28,7 +28,7 @@ def split_name(name):
     res = re.match('(?P<prefix>\D*)(?P<basename>.*)', name)
     name_info = res.groupdict()
     if name_info['prefix'] == 'FRB':
-        name_info['tns_objname'] = name_info
+        name_info['tns_objname'] = name
     elif name_info['prefix'] in TNS_PREFIXES:
         name_info['tns_objname'] = name_info['basename']
     else:

--- a/custom_code/templatetags/target_extras.py
+++ b/custom_code/templatetags/target_extras.py
@@ -26,14 +26,14 @@ def ecliptic_lat(target):
 def split_name(name):
     """Splits the name into a prefix, consisting of no digits, and a basename, which starts with its first digit"""
     res = re.match('(?P<prefix>\D*)(?P<basename>.*)', name)
-    name = res.groupdict()
-    if name['prefix'] == 'FRB':
-        name['tns_objname'] = name
-    elif name['prefix'] in TNS_PREFIXES:
-        name['tns_objname'] = name['basename']
+    name_info = res.groupdict()
+    if name_info['prefix'] == 'FRB':
+        name_info['tns_objname'] = name_info
+    elif name_info['prefix'] in TNS_PREFIXES:
+        name_info['tns_objname'] = name_info['basename']
     else:
-        name['tns_objname'] = None
-    return name
+        name_info['tns_objname'] = None
+    return name_info
 
 
 @register.inclusion_tag('tom_targets/partials/aladin_custom.html')

--- a/templates/tom_targets/partials/target_buttons.html
+++ b/templates/tom_targets/partials/target_buttons.html
@@ -1,6 +1,6 @@
 {% load targets_extras target_extras %}
 {% with target.name|split_name as name %}
-{% if name.has_tns_prefix %}
+{% if name.tns_objname %}
     <a href="{% url 'custom_code:classify' pk=target.id %}" title="Classify target on TNS" class="btn btn-secondary">Classify</a>
 {% else %}
     <a href="{% url 'custom_code:report' pk=target.id %}" title="Report target to TNS" class="btn btn-secondary">Report</a>

--- a/templates/tom_targets/partials/target_data.html
+++ b/templates/tom_targets/partials/target_data.html
@@ -9,8 +9,8 @@
     <dd class="col-sm-9">
         {{ target_name }}
         {% with target_name|split_name as name %}
-        {% if name.has_tns_prefix %}
-            <a href="https://www.wis-tns.org/object/{{ name.basename }}" target="_blank"><img src="https://www.wis-tns.org/sites/default/files/favicon.png" alt="TNS" title="TNS" class="icon" /></a>
+        {% if name.tns_objname %}
+            <a href="https://www.wis-tns.org/object/{{ name.tns_objname }}" target="_blank"><img src="https://www.wis-tns.org/sites/default/files/favicon.png" alt="TNS" title="TNS" class="icon" /></a>
         {% elif name.prefix == "ZTF" %}
             <a href="https://alerce.online/object/{{ target_name }}" target="_blank"><img src="https://alerce.online/favicon.ico" alt="ALeRCE" title="ALeRCE" class="icon" /></a>
             <a href="https://antares.noirlab.edu/loci/lookup/{{ target_name }}" target="_blank"><img src="https://antares.noirlab.edu/favicon.ico" alt="ANTARES" title="ANTARES" class="icon" /></a>


### PR DESCRIPTION
The TNS has a different URL format for FRBs than for optical transients. Previously, this caused the vetting code to crash for targets with FRB prefixes (or an AT at the same coordinates of an FRB). See point 3 in #141.

This PR now recognizes FRBs as TNS transients, fixes the TNS URL, and avoids ingesting FRB photometry from the TNS, which has neither a magnitude nor a limiting magnitude. Manually added FRBs can be vetted freely. There could still be some confusion if there is an FRB and an AT within 2" of each other, so #141 is not resolved.