### PR TITLE
initial configuration of `tom-registration`

### DIFF
--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -1,6 +1,7 @@
 from tom_nonlocalizedevents.models import NonLocalizedEvent, EventSequence, EventCandidate
 from tom_nonlocalizedevents.alertstream_handlers.igwn_event_handler import handle_igwn_message
 from django.contrib.auth.models import Group
+from django.contrib.sites.models import Site
 from django.conf import settings
 from django.urls import reverse
 import urllib
@@ -137,7 +138,7 @@ def send_email(subject, body, is_test_alert=False):
     """This doesn't currently work"""
     msg = MIMEText(body)
     msg['Subject'] = subject
-    msg['From'] = settings.ALERT_EMAIL_FROM
+    msg['From'] = settings.SERVER_EMAIL
     group = Group.objects.get(name='Test Email Alerts') if is_test_alert else Group.objects.get(name='Email Alerts')
     msg['To'] = ','.join([u.email.split(',')[0] for u in group.user_set.all()])
     if not msg['To']:
@@ -345,7 +346,7 @@ def handle_einstein_probe_alert(message, metadata):
     EventCandidate.objects.create(target=t_ep, nonlocalizedevent=nonlocalizedevent)
     vet_or_post_error(t_ep, slack_ep, channel='alerts-ep')
     query = {'localization_event': nonlocalizedevent.event_id, 'localization_prob': 95, 'localization_dt': 3}
-    survey_obs_link = f"https://{settings.ALLOWED_HOST}{reverse('surveys:observations')}?{urllib.parse.urlencode(query)}"
+    survey_obs_link = f"https://{Site.objects.get_current().domain}{reverse('surveys:observations')}?{urllib.parse.urlencode(query)}"
     alert_text = ALERT_TEXT_EP.format(survey_obs_link=survey_obs_link, target_link=settings.TARGET_LINKS[0][0]
                                      ).format(target=t_ep)
     logger.info(f'Sending EP alert: {alert_text}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ tomtoolkit==2.24.5
 tom-alertstreams
 tom-mmt @ git+https://github.com/griffin-h/tom_mmt
 tom-nonlocalizedevents @ git+https://github.com/TOMToolkit/tom_nonlocalizedevents.git
+tom-registration
 tom-swift==0.2.0
 paramiko
 plotly

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = [
     'tom_dataproducts',
     'tom_alertstreams',
     'tom_nonlocalizedevents',
+    'tom_registration',
     'webpack_loader',
     'custom_code',
     'tom_surveys',
@@ -64,8 +65,6 @@ INSTALLED_APPS = [
     'django_tasks',
     'django_tasks.backends.database',
 ]
-
-SITE_ID = 1
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
@@ -79,6 +78,7 @@ MIDDLEWARE = [
     'tom_common.middleware.Raise403Middleware',
     'tom_common.middleware.ExternalServiceMiddleware',
     'tom_common.middleware.AuthStrategyMiddleware',
+    'tom_registration.middleware.RedirectAuthenticatedUsersFromRegisterMiddleware',
 ]
 
 ROOT_URLCONF = 'saguaro_tom.urls'
@@ -150,7 +150,7 @@ LOGIN_REDIRECT_URL = FORCE_SCRIPT_NAME + '/'
 LOGOUT_REDIRECT_URL = FORCE_SCRIPT_NAME + '/'
 
 AUTHENTICATION_BACKENDS = (
-    'django.contrib.auth.backends.ModelBackend',
+    'django.contrib.auth.backends.AllowAllUsersModelBackend',
     'guardian.backends.ObjectPermissionBackend',
 )
 
@@ -345,7 +345,7 @@ TARGET_PERMISSIONS_ONLY = True
 
 # URLs that should be allowed access even with AUTH_STRATEGY = LOCKED
 # for example: OPEN_URLS = ['/', '/about']
-OPEN_URLS = []
+OPEN_URLS = ['/accounts/register/']
 
 MATCH_MANAGERS = {'Target': 'custom_code.managers.StrictTargetMatchManager'}
 
@@ -416,3 +416,14 @@ WEBPACK_LOADER = {
 TOM_API_URL = os.getenv('TOM_API_URL', os.path.join(ALLOWED_HOST, FORCE_SCRIPT_NAME))
 HERMES_API_URL = os.getenv('HERMES_API_URL', 'https://hermes.lco.global')
 CREDIBLE_REGION_PROBABILITIES = '[0.25, 0.5, 0.75, 0.9, 0.95]'
+
+TOM_REGISTRATION = {
+    'REGISTRATION_AUTHENTICATION_BACKEND': 'django.contrib.auth.backends.AllowAllUsersModelBackend',
+    'REGISTRATION_REDIRECT_PATTERN': 'home',
+    'REGISTRATION_STRATEGY': 'approval_required',
+    'SEND_APPROVAL_EMAILS': True,
+    'APPROVAL_SUBJECT': f'Congratulations!! Welcome to {TOM_NAME}!',
+}
+EMAIL_SUBJECT_PREFIX = ''
+EMAIL_USE_TLS = True
+SERVER_EMAIL = f'Salsa Saguaro <{EMAIL_HOST_USER}>'

--- a/saguaro_tom/settings_local.template.py
+++ b/saguaro_tom/settings_local.template.py
@@ -1,4 +1,3 @@
-ALERT_EMAIL_FROM = ''   # email address from which the alerts are sent
 ALLOWED_HOST = ''       # hostname or IP address of the web server (leave blank for development)
 ATLAS_API_KEY = ''      # API key for the ATLAS forced photometry server
 CONTACT_EMAIL = ''      # contact email for MMT observation request notes

--- a/saguaro_tom/settings_local.template.py
+++ b/saguaro_tom/settings_local.template.py
@@ -6,6 +6,10 @@ CSS_HOSTNAME = ''       # hostname to which to send CSS .prog files
 CSS_USERNAME = ''       # username (on CSS_HOSTNAME) to which to send CSS .prog files
 CSS_DIRNAME = ''        # directory (on CSS_HOSTNAME) in which to put CSS .prog files
 DEBUG = False           # set to True to display error tracebacks in browser, leave False in production
+EMAIL_HOST = ''         # SMTP server for sending emails
+EMAIL_HOST_USER = ''    # email address for the account sending emails
+EMAIL_HOST_PASSWORD = ''  # password for the account sending emails (app password for Gmail)
+EMAIL_PORT = 587        # port for the SMTP server
 FORCE_SCRIPT_NAME = ''  # the subdomain where you will host the site (leave blank for development)
 GCN_CLIENT_ID = ''      # client ID for GCN Classic over Kafka
 GCN_CLIENT_SECRET = ''  # secret key for GCN Classic over Kafka
@@ -14,6 +18,9 @@ GEM_S_API_KEY = ''      # API key for Gemini Observatory South
 HOPSKOTCH_GROUP_ID = '' # make up a unique ID for your Hopskotch alert consumer
 LASAIR_TOKEN = ''       # API key for the Lasair broker
 LCO_API_KEY = ''        # API key for Las Cumbres Observatory
+MANAGERS = [            # list of managers who should receive registration emails
+    ('Name', 'email'),
+]
 MMT_BINOSPEC_PROGRAMS = [] # list of (API key, human-readable name) for MMT+Binospec
 MMT_MMIRS_PROGRAMS = [] # list of (API key, human-readable name) for MMT+MMIRS
 MMT_MMTCAM_PROGRAMS = [] # list of (API key, human-readable name) for MMT+MMTCam
@@ -34,6 +41,7 @@ TARGET_LINKS = [  # links to TOMs for target pages, {target.name} is replaced by
     ('https://tom0.edu/targets/{target.id}/', 'Name of TOM 0'),  # TOM corresponding to Slack workspace 0
     ('https://tom1.edu/targets/{target.name}/', 'Name of TOM 1'),  # TOM corresponding to Slack workspace 1
 ]
+SITE_ID = 1  # set to 1 for production site, 2 for local development
 SLACK_TOKENS_GW = [  # Slack API tokens for GW alerts
     '',  # Slack workspace 0
     '',  # Slack workspace 1


### PR DESCRIPTION
Resolves #143 by installing the `tom-registration` app and configuring the account request and approval workflow.

Some changes are required to `settings_local.py` to test this PR:
1. Configuring the email backend by adding `EMAIL_HOST`, `EMAIL_HOST_USER`, `EMAIL_HOST_PASSWORD`, and `EMAIL_PORT`
2. Adding one or more `MANAGERS`
3. Moving the `SITE_ID` variable from `settings.py` to `settings_local.py`. Use `SITE_ID = 2` for local testing.

Keep in mind that the built-in Django development server does not support HTTPS, so the links in the emails won't work perfectly. They should work locally if you change `https` to `http`, and they should work in the production server.