### PR TITLE
send alert handlers to django_tasks queue

### DIFF
--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -355,3 +355,11 @@ def handle_einstein_probe_alert(message, metadata):
     slack_ep.chat_postMessage(channel='alerts-ep', text=alert_text)
 
     logger.info(f'Finished processing alert for {nonlocalizedevent.event_id}')
+
+
+def handle_message_and_send_alerts_async(message, metadata):
+    handle_message_and_send_alerts.enqueue(message, metadata)
+
+
+def handle_einstein_probe_alert_async(message, metadata):
+    handle_einstein_probe_alert.enqueue(message, metadata)

--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -3,6 +3,7 @@ from tom_nonlocalizedevents.alertstream_handlers.igwn_event_handler import handl
 from django.contrib.auth.models import Group
 from django.conf import settings
 from django.urls import reverse
+from django_tasks import task
 import urllib
 from email.mime.text import MIMEText
 from slack_sdk import WebClient
@@ -249,6 +250,7 @@ def prepare_and_send_alerts(nle, seq):
     return localizations
 
 
+@task(queue_name='nonlocalizedevents')
 def handle_message_and_send_alerts(message, metadata):
     # get skymap bytes out for later
     skymaps = []
@@ -286,6 +288,7 @@ def handle_message_and_send_alerts(message, metadata):
     logger.info(f'Finished processing alert for {nle.event_id}')
 
 
+@task(queue_name='nonlocalizedevents')
 def handle_einstein_probe_alert(message, metadata):
     alert = message.content
     logger.warning(f"Handling Einstein Probe alert: {alert}")

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -394,8 +394,8 @@ ALERT_STREAMS = [
             'USERNAME': os.getenv('SCIMMA_AUTH_USERNAME', SCIMMA_AUTH_USERNAME),
             'PASSWORD': os.getenv('SCIMMA_AUTH_PASSWORD', SCIMMA_AUTH_PASSWORD),
             'TOPIC_HANDLERS': {
-                'gcn.notices.einstein_probe.wxt.alert': 'custom_code.alertstream_handlers.handle_einstein_probe_alert',
-                'igwn.gwalert': 'custom_code.alertstream_handlers.handle_message_and_send_alerts',
+                'gcn.notices.einstein_probe.wxt.alert': 'custom_code.alertstream_handlers.handle_einstein_probe_alert.enqueue',
+                'igwn.gwalert': 'custom_code.alertstream_handlers.handle_message_and_send_alerts.enqueue',
                 'icecube.HE-tracks': 'tom_alertstreams.alertstreams.hopskotch.alert_logger',
             },
         },

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -394,8 +394,8 @@ ALERT_STREAMS = [
             'USERNAME': os.getenv('SCIMMA_AUTH_USERNAME', SCIMMA_AUTH_USERNAME),
             'PASSWORD': os.getenv('SCIMMA_AUTH_PASSWORD', SCIMMA_AUTH_PASSWORD),
             'TOPIC_HANDLERS': {
-                'gcn.notices.einstein_probe.wxt.alert': 'custom_code.alertstream_handlers.handle_einstein_probe_alert.enqueue',
-                'igwn.gwalert': 'custom_code.alertstream_handlers.handle_message_and_send_alerts.enqueue',
+                'gcn.notices.einstein_probe.wxt.alert': 'custom_code.alertstream_handlers.handle_einstein_probe_alert_async',
+                'igwn.gwalert': 'custom_code.alertstream_handlers.handle_message_and_send_alerts_async',
                 'icecube.HE-tracks': 'tom_alertstreams.alertstreams.hopskotch.alert_logger',
             },
         },

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -107,7 +107,7 @@ WSGI_APPLICATION = 'saguaro_tom.wsgi.application'
 TASKS = {
     "default": {
         "BACKEND": "django_tasks.backends.database.DatabaseBackend",
-        "QUEUES": ["default", "mpc"]
+        "QUEUES": ["default", "mpc", "nonlocalizedevents"]
     }
 }
 


### PR DESCRIPTION
Resolves #139 by turning the alert handler functions into asynchronous tasks.